### PR TITLE
Add bulk API regex ruleset generator and templates

### DIFF
--- a/automations/build_api_regex_rules.py
+++ b/automations/build_api_regex_rules.py
@@ -1,0 +1,189 @@
+"""Utility for generating bulk API regex scanning templates."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TEMPLATE_PATH = REPO_ROOT / "automations" / "templates.json"
+
+
+BASE_SEVERITY = {
+    "critical": ["critical", "high", "high", "medium"],
+    "high": ["high", "high", "medium", "medium"],
+    "medium": ["medium", "medium", "low", "medium"],
+}
+
+CATEGORIES = [
+    "access-management",
+    "accounting",
+    "analytics",
+    "audit",
+    "billing",
+    "business-intelligence",
+    "cloud-ops",
+    "collaboration",
+    "commerce",
+    "compliance",
+    "customer-success",
+    "devops",
+    "finance",
+    "governance",
+    "identity",
+    "infrastructure",
+    "logistics",
+    "marketing",
+    "operations",
+    "product",
+]
+
+EXPOSURES = [
+    {
+        "slug": "token-cache",
+        "title": "Token Cache Dump",
+        "path_template": "/api/{category_slug}/token-cache-{index_padded}.json",
+        "description": "Detects exposed {category_title} token cache exports leaking bearer secrets.",
+        "severity": "high",
+        "regex_terms": ["token", "secret", "bearer"],
+        "tags": ["api", "credentials", "{category_slug}"],
+    },
+    {
+        "slug": "session-ledger",
+        "title": "Session Ledger Leak",
+        "path_template": "/api/{category_slug}/sessions-ledger-{index_padded}.log",
+        "description": "Catches leaked {category_title} session ledgers disclosing JWTs and expirations.",
+        "severity": "high",
+        "regex_terms": ["session", "jwt", "exp"],
+        "tags": ["api", "sessions", "{category_slug}"],
+    },
+    {
+        "slug": "config-export",
+        "title": "Config Export Exposure",
+        "path_template": "/api/{category_slug}/config-export-{index_padded}.yaml",
+        "description": "Finds world-readable {category_title} configuration exports exposing environment secrets.",
+        "severity": "high",
+        "regex_terms": ["config", "environment", "secret"],
+        "tags": ["api", "config", "{category_slug}"],
+    },
+    {
+        "slug": "user-dump",
+        "title": "User Dump Exposure",
+        "path_template": "/api/{category_slug}/user-dump-{index_padded}.csv",
+        "description": "Detects exposed {category_title} user exports leaking directory records.",
+        "severity": "medium",
+        "regex_terms": ["email", "user", "id"],
+        "tags": ["api", "intel", "{category_slug}"],
+    },
+    {
+        "slug": "billing-export",
+        "title": "Billing Export Exposure",
+        "path_template": "/api/{category_slug}/billing-export-{index_padded}.csv",
+        "description": "Identifies {category_title} billing exports containing transaction data.",
+        "severity": "medium",
+        "regex_terms": ["invoice", "amount", "currency"],
+        "tags": ["api", "billing", "{category_slug}"],
+    },
+    {
+        "slug": "webhook-registry",
+        "title": "Webhook Registry Leak",
+        "path_template": "/api/{category_slug}/webhooks-registry-{index_padded}.json",
+        "description": "Detects leaked {category_title} webhook registries exposing callback secrets.",
+        "severity": "high",
+        "regex_terms": ["webhook", "callback", "signature"],
+        "tags": ["api", "integrations", "{category_slug}"],
+    },
+    {
+        "slug": "telemetry-snapshot",
+        "title": "Telemetry Snapshot Exposure",
+        "path_template": "/api/{category_slug}/telemetry-snapshot-{index_padded}.json",
+        "description": "Surfaces exposed {category_title} telemetry snapshots leaking internal metrics.",
+        "severity": "medium",
+        "regex_terms": ["telemetry", "metric", "timestamp"],
+        "tags": ["api", "telemetry", "{category_slug}"],
+    },
+    {
+        "slug": "debug-trace",
+        "title": "Debug Trace Log Leak",
+        "path_template": "/api/{category_slug}/debug-trace-{index_padded}.log",
+        "description": "Detects leaked {category_title} debug traces revealing stack data.",
+        "severity": "medium",
+        "regex_terms": ["trace", "exception", "stack"],
+        "tags": ["api", "debug", "{category_slug}"],
+    },
+    {
+        "slug": "database-backup",
+        "title": "Database Backup Exposure",
+        "path_template": "/api/{category_slug}/db-backup-{index_padded}.sql",
+        "description": "Finds exposed {category_title} database backups with raw records.",
+        "severity": "high",
+        "regex_terms": ["insert", "password", "api_key"],
+        "tags": ["api", "database", "{category_slug}"],
+    },
+    {
+        "slug": "compliance-report",
+        "title": "Compliance Report Leak",
+        "path_template": "/api/{category_slug}/compliance-report-{index_padded}.pdf",
+        "description": "Detects leaked {category_title} compliance reports disclosing control evidence.",
+        "severity": "medium",
+        "regex_terms": ["compliance", "control", "finding"],
+        "tags": ["api", "compliance", "{category_slug}"],
+    },
+]
+
+
+def slugify(value: str) -> str:
+    """Return a filesystem and URL friendly slug."""
+    cleaned = "".join(ch if ch.isalnum() else "-" for ch in value.lower())
+    cleaned = "-".join(filter(None, cleaned.split("-")))
+    return cleaned or "category"
+
+
+def build_templates(existing_ids: Iterable[str]) -> list[dict[str, object]]:
+    templates: list[dict[str, object]] = []
+    for category in CATEGORIES:
+        category_slug = slugify(category)
+        category_title = category.replace("-", " ").title()
+        for exposure in EXPOSURES:
+            severity_cycle = BASE_SEVERITY[exposure["severity"]]
+            for index in range(1, 6):
+                severity = severity_cycle[(index - 1) % len(severity_cycle)]
+                context = {
+                    "category": category,
+                    "category_slug": category_slug,
+                    "category_title": category_title,
+                    "index": index,
+                    "index_padded": f"{index:02d}",
+                }
+                template_id = f"api-regex-{exposure['slug']}-{category_slug}-{index:02d}"
+                if template_id in existing_ids:
+                    continue
+                template = {
+                    "id": template_id,
+                    "name": f"{category_title} {exposure['title']} #{index}",
+                    "description": exposure["description"].format(**context),
+                    "severity": severity,
+                    "method": "GET",
+                    "path": exposure["path_template"].format(**context),
+                    "matchers": {
+                        "status": [200],
+                        "regex": [f"(?i){term}" for term in exposure["regex_terms"]],
+                    },
+                    "tags": [tag.format(**context) for tag in exposure["tags"]],
+                }
+                templates.append(template)
+    return templates
+
+
+def main() -> None:
+    payload = json.loads(TEMPLATE_PATH.read_text())
+    existing_ids = {entry.get("id") for entry in payload if isinstance(entry, dict)}
+    additions = build_templates(existing_ids)
+    payload.extend(additions)
+    TEMPLATE_PATH.write_text(json.dumps(payload, indent=2))
+    print(f"Added {len(additions)} templates. Total now {len(payload)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/automations/templates.json
+++ b/automations/templates.json
@@ -21123,5 +21123,23005 @@
       "credentials",
       "jira"
     ]
+  },
+  {
+    "id": "api-regex-token-cache-access-management-01",
+    "name": "Access Management Token Cache Dump #1",
+    "description": "Detects exposed Access Management token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/token-cache-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-access-management-02",
+    "name": "Access Management Token Cache Dump #2",
+    "description": "Detects exposed Access Management token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/token-cache-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-access-management-03",
+    "name": "Access Management Token Cache Dump #3",
+    "description": "Detects exposed Access Management token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/token-cache-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-access-management-04",
+    "name": "Access Management Token Cache Dump #4",
+    "description": "Detects exposed Access Management token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/token-cache-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-access-management-05",
+    "name": "Access Management Token Cache Dump #5",
+    "description": "Detects exposed Access Management token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/token-cache-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-access-management-01",
+    "name": "Access Management Session Ledger Leak #1",
+    "description": "Catches leaked Access Management session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/sessions-ledger-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-access-management-02",
+    "name": "Access Management Session Ledger Leak #2",
+    "description": "Catches leaked Access Management session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/sessions-ledger-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-access-management-03",
+    "name": "Access Management Session Ledger Leak #3",
+    "description": "Catches leaked Access Management session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/sessions-ledger-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-access-management-04",
+    "name": "Access Management Session Ledger Leak #4",
+    "description": "Catches leaked Access Management session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/sessions-ledger-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-access-management-05",
+    "name": "Access Management Session Ledger Leak #5",
+    "description": "Catches leaked Access Management session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/sessions-ledger-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-access-management-01",
+    "name": "Access Management Config Export Exposure #1",
+    "description": "Finds world-readable Access Management configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/config-export-01.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-access-management-02",
+    "name": "Access Management Config Export Exposure #2",
+    "description": "Finds world-readable Access Management configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/config-export-02.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-access-management-03",
+    "name": "Access Management Config Export Exposure #3",
+    "description": "Finds world-readable Access Management configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/config-export-03.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-access-management-04",
+    "name": "Access Management Config Export Exposure #4",
+    "description": "Finds world-readable Access Management configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/config-export-04.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-access-management-05",
+    "name": "Access Management Config Export Exposure #5",
+    "description": "Finds world-readable Access Management configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/config-export-05.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-access-management-01",
+    "name": "Access Management User Dump Exposure #1",
+    "description": "Detects exposed Access Management user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/user-dump-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-access-management-02",
+    "name": "Access Management User Dump Exposure #2",
+    "description": "Detects exposed Access Management user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/user-dump-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-access-management-03",
+    "name": "Access Management User Dump Exposure #3",
+    "description": "Detects exposed Access Management user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/access-management/user-dump-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-access-management-04",
+    "name": "Access Management User Dump Exposure #4",
+    "description": "Detects exposed Access Management user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/user-dump-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-access-management-05",
+    "name": "Access Management User Dump Exposure #5",
+    "description": "Detects exposed Access Management user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/user-dump-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-access-management-01",
+    "name": "Access Management Billing Export Exposure #1",
+    "description": "Identifies Access Management billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/billing-export-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-access-management-02",
+    "name": "Access Management Billing Export Exposure #2",
+    "description": "Identifies Access Management billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/billing-export-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-access-management-03",
+    "name": "Access Management Billing Export Exposure #3",
+    "description": "Identifies Access Management billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/access-management/billing-export-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-access-management-04",
+    "name": "Access Management Billing Export Exposure #4",
+    "description": "Identifies Access Management billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/billing-export-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-access-management-05",
+    "name": "Access Management Billing Export Exposure #5",
+    "description": "Identifies Access Management billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/billing-export-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-access-management-01",
+    "name": "Access Management Webhook Registry Leak #1",
+    "description": "Detects leaked Access Management webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/webhooks-registry-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-access-management-02",
+    "name": "Access Management Webhook Registry Leak #2",
+    "description": "Detects leaked Access Management webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/webhooks-registry-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-access-management-03",
+    "name": "Access Management Webhook Registry Leak #3",
+    "description": "Detects leaked Access Management webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/webhooks-registry-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-access-management-04",
+    "name": "Access Management Webhook Registry Leak #4",
+    "description": "Detects leaked Access Management webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/webhooks-registry-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-access-management-05",
+    "name": "Access Management Webhook Registry Leak #5",
+    "description": "Detects leaked Access Management webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/webhooks-registry-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-access-management-01",
+    "name": "Access Management Telemetry Snapshot Exposure #1",
+    "description": "Surfaces exposed Access Management telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/telemetry-snapshot-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-access-management-02",
+    "name": "Access Management Telemetry Snapshot Exposure #2",
+    "description": "Surfaces exposed Access Management telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/telemetry-snapshot-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-access-management-03",
+    "name": "Access Management Telemetry Snapshot Exposure #3",
+    "description": "Surfaces exposed Access Management telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/access-management/telemetry-snapshot-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-access-management-04",
+    "name": "Access Management Telemetry Snapshot Exposure #4",
+    "description": "Surfaces exposed Access Management telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/telemetry-snapshot-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-access-management-05",
+    "name": "Access Management Telemetry Snapshot Exposure #5",
+    "description": "Surfaces exposed Access Management telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/telemetry-snapshot-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-access-management-01",
+    "name": "Access Management Debug Trace Log Leak #1",
+    "description": "Detects leaked Access Management debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/debug-trace-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-access-management-02",
+    "name": "Access Management Debug Trace Log Leak #2",
+    "description": "Detects leaked Access Management debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/debug-trace-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-access-management-03",
+    "name": "Access Management Debug Trace Log Leak #3",
+    "description": "Detects leaked Access Management debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/access-management/debug-trace-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-access-management-04",
+    "name": "Access Management Debug Trace Log Leak #4",
+    "description": "Detects leaked Access Management debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/debug-trace-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-access-management-05",
+    "name": "Access Management Debug Trace Log Leak #5",
+    "description": "Detects leaked Access Management debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/debug-trace-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-access-management-01",
+    "name": "Access Management Database Backup Exposure #1",
+    "description": "Finds exposed Access Management database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/db-backup-01.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-access-management-02",
+    "name": "Access Management Database Backup Exposure #2",
+    "description": "Finds exposed Access Management database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/db-backup-02.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-access-management-03",
+    "name": "Access Management Database Backup Exposure #3",
+    "description": "Finds exposed Access Management database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/db-backup-03.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-access-management-04",
+    "name": "Access Management Database Backup Exposure #4",
+    "description": "Finds exposed Access Management database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/db-backup-04.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-access-management-05",
+    "name": "Access Management Database Backup Exposure #5",
+    "description": "Finds exposed Access Management database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/db-backup-05.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-access-management-01",
+    "name": "Access Management Compliance Report Leak #1",
+    "description": "Detects leaked Access Management compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/compliance-report-01.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-access-management-02",
+    "name": "Access Management Compliance Report Leak #2",
+    "description": "Detects leaked Access Management compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/compliance-report-02.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-access-management-03",
+    "name": "Access Management Compliance Report Leak #3",
+    "description": "Detects leaked Access Management compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/access-management/compliance-report-03.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-access-management-04",
+    "name": "Access Management Compliance Report Leak #4",
+    "description": "Detects leaked Access Management compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/compliance-report-04.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-access-management-05",
+    "name": "Access Management Compliance Report Leak #5",
+    "description": "Detects leaked Access Management compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/compliance-report-05.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-accounting-01",
+    "name": "Accounting Token Cache Dump #1",
+    "description": "Detects exposed Accounting token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/token-cache-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-accounting-02",
+    "name": "Accounting Token Cache Dump #2",
+    "description": "Detects exposed Accounting token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/token-cache-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-accounting-03",
+    "name": "Accounting Token Cache Dump #3",
+    "description": "Detects exposed Accounting token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/token-cache-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-accounting-04",
+    "name": "Accounting Token Cache Dump #4",
+    "description": "Detects exposed Accounting token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/token-cache-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-accounting-05",
+    "name": "Accounting Token Cache Dump #5",
+    "description": "Detects exposed Accounting token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/token-cache-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-accounting-01",
+    "name": "Accounting Session Ledger Leak #1",
+    "description": "Catches leaked Accounting session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/sessions-ledger-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-accounting-02",
+    "name": "Accounting Session Ledger Leak #2",
+    "description": "Catches leaked Accounting session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/sessions-ledger-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-accounting-03",
+    "name": "Accounting Session Ledger Leak #3",
+    "description": "Catches leaked Accounting session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/sessions-ledger-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-accounting-04",
+    "name": "Accounting Session Ledger Leak #4",
+    "description": "Catches leaked Accounting session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/sessions-ledger-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-accounting-05",
+    "name": "Accounting Session Ledger Leak #5",
+    "description": "Catches leaked Accounting session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/sessions-ledger-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-accounting-01",
+    "name": "Accounting Config Export Exposure #1",
+    "description": "Finds world-readable Accounting configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/config-export-01.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-accounting-02",
+    "name": "Accounting Config Export Exposure #2",
+    "description": "Finds world-readable Accounting configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/config-export-02.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-accounting-03",
+    "name": "Accounting Config Export Exposure #3",
+    "description": "Finds world-readable Accounting configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/config-export-03.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-accounting-04",
+    "name": "Accounting Config Export Exposure #4",
+    "description": "Finds world-readable Accounting configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/config-export-04.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-accounting-05",
+    "name": "Accounting Config Export Exposure #5",
+    "description": "Finds world-readable Accounting configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/config-export-05.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-accounting-01",
+    "name": "Accounting User Dump Exposure #1",
+    "description": "Detects exposed Accounting user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/user-dump-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-accounting-02",
+    "name": "Accounting User Dump Exposure #2",
+    "description": "Detects exposed Accounting user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/user-dump-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-accounting-03",
+    "name": "Accounting User Dump Exposure #3",
+    "description": "Detects exposed Accounting user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/accounting/user-dump-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-accounting-04",
+    "name": "Accounting User Dump Exposure #4",
+    "description": "Detects exposed Accounting user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/user-dump-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-accounting-05",
+    "name": "Accounting User Dump Exposure #5",
+    "description": "Detects exposed Accounting user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/user-dump-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-accounting-01",
+    "name": "Accounting Billing Export Exposure #1",
+    "description": "Identifies Accounting billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/billing-export-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-accounting-02",
+    "name": "Accounting Billing Export Exposure #2",
+    "description": "Identifies Accounting billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/billing-export-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-accounting-03",
+    "name": "Accounting Billing Export Exposure #3",
+    "description": "Identifies Accounting billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/accounting/billing-export-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-accounting-04",
+    "name": "Accounting Billing Export Exposure #4",
+    "description": "Identifies Accounting billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/billing-export-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-accounting-05",
+    "name": "Accounting Billing Export Exposure #5",
+    "description": "Identifies Accounting billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/billing-export-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-accounting-01",
+    "name": "Accounting Webhook Registry Leak #1",
+    "description": "Detects leaked Accounting webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/webhooks-registry-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-accounting-02",
+    "name": "Accounting Webhook Registry Leak #2",
+    "description": "Detects leaked Accounting webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/webhooks-registry-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-accounting-03",
+    "name": "Accounting Webhook Registry Leak #3",
+    "description": "Detects leaked Accounting webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/webhooks-registry-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-accounting-04",
+    "name": "Accounting Webhook Registry Leak #4",
+    "description": "Detects leaked Accounting webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/webhooks-registry-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-accounting-05",
+    "name": "Accounting Webhook Registry Leak #5",
+    "description": "Detects leaked Accounting webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/webhooks-registry-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-accounting-01",
+    "name": "Accounting Telemetry Snapshot Exposure #1",
+    "description": "Surfaces exposed Accounting telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/telemetry-snapshot-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-accounting-02",
+    "name": "Accounting Telemetry Snapshot Exposure #2",
+    "description": "Surfaces exposed Accounting telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/telemetry-snapshot-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-accounting-03",
+    "name": "Accounting Telemetry Snapshot Exposure #3",
+    "description": "Surfaces exposed Accounting telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/accounting/telemetry-snapshot-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-accounting-04",
+    "name": "Accounting Telemetry Snapshot Exposure #4",
+    "description": "Surfaces exposed Accounting telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/telemetry-snapshot-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-accounting-05",
+    "name": "Accounting Telemetry Snapshot Exposure #5",
+    "description": "Surfaces exposed Accounting telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/telemetry-snapshot-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-accounting-01",
+    "name": "Accounting Debug Trace Log Leak #1",
+    "description": "Detects leaked Accounting debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/debug-trace-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-accounting-02",
+    "name": "Accounting Debug Trace Log Leak #2",
+    "description": "Detects leaked Accounting debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/debug-trace-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-accounting-03",
+    "name": "Accounting Debug Trace Log Leak #3",
+    "description": "Detects leaked Accounting debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/accounting/debug-trace-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-accounting-04",
+    "name": "Accounting Debug Trace Log Leak #4",
+    "description": "Detects leaked Accounting debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/debug-trace-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-accounting-05",
+    "name": "Accounting Debug Trace Log Leak #5",
+    "description": "Detects leaked Accounting debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/debug-trace-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-accounting-01",
+    "name": "Accounting Database Backup Exposure #1",
+    "description": "Finds exposed Accounting database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/db-backup-01.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-accounting-02",
+    "name": "Accounting Database Backup Exposure #2",
+    "description": "Finds exposed Accounting database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/db-backup-02.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-accounting-03",
+    "name": "Accounting Database Backup Exposure #3",
+    "description": "Finds exposed Accounting database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/db-backup-03.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-accounting-04",
+    "name": "Accounting Database Backup Exposure #4",
+    "description": "Finds exposed Accounting database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/db-backup-04.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-accounting-05",
+    "name": "Accounting Database Backup Exposure #5",
+    "description": "Finds exposed Accounting database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/db-backup-05.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-accounting-01",
+    "name": "Accounting Compliance Report Leak #1",
+    "description": "Detects leaked Accounting compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/compliance-report-01.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-accounting-02",
+    "name": "Accounting Compliance Report Leak #2",
+    "description": "Detects leaked Accounting compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/compliance-report-02.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-accounting-03",
+    "name": "Accounting Compliance Report Leak #3",
+    "description": "Detects leaked Accounting compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/accounting/compliance-report-03.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-accounting-04",
+    "name": "Accounting Compliance Report Leak #4",
+    "description": "Detects leaked Accounting compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/compliance-report-04.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-accounting-05",
+    "name": "Accounting Compliance Report Leak #5",
+    "description": "Detects leaked Accounting compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/compliance-report-05.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-analytics-01",
+    "name": "Analytics Token Cache Dump #1",
+    "description": "Detects exposed Analytics token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/token-cache-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-analytics-02",
+    "name": "Analytics Token Cache Dump #2",
+    "description": "Detects exposed Analytics token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/token-cache-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-analytics-03",
+    "name": "Analytics Token Cache Dump #3",
+    "description": "Detects exposed Analytics token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/token-cache-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-analytics-04",
+    "name": "Analytics Token Cache Dump #4",
+    "description": "Detects exposed Analytics token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/token-cache-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-analytics-05",
+    "name": "Analytics Token Cache Dump #5",
+    "description": "Detects exposed Analytics token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/token-cache-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-analytics-01",
+    "name": "Analytics Session Ledger Leak #1",
+    "description": "Catches leaked Analytics session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/sessions-ledger-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-analytics-02",
+    "name": "Analytics Session Ledger Leak #2",
+    "description": "Catches leaked Analytics session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/sessions-ledger-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-analytics-03",
+    "name": "Analytics Session Ledger Leak #3",
+    "description": "Catches leaked Analytics session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/sessions-ledger-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-analytics-04",
+    "name": "Analytics Session Ledger Leak #4",
+    "description": "Catches leaked Analytics session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/sessions-ledger-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-analytics-05",
+    "name": "Analytics Session Ledger Leak #5",
+    "description": "Catches leaked Analytics session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/sessions-ledger-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-analytics-01",
+    "name": "Analytics Config Export Exposure #1",
+    "description": "Finds world-readable Analytics configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/config-export-01.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-analytics-02",
+    "name": "Analytics Config Export Exposure #2",
+    "description": "Finds world-readable Analytics configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/config-export-02.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-analytics-03",
+    "name": "Analytics Config Export Exposure #3",
+    "description": "Finds world-readable Analytics configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/config-export-03.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-analytics-04",
+    "name": "Analytics Config Export Exposure #4",
+    "description": "Finds world-readable Analytics configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/config-export-04.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-analytics-05",
+    "name": "Analytics Config Export Exposure #5",
+    "description": "Finds world-readable Analytics configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/config-export-05.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-analytics-01",
+    "name": "Analytics User Dump Exposure #1",
+    "description": "Detects exposed Analytics user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/user-dump-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-analytics-02",
+    "name": "Analytics User Dump Exposure #2",
+    "description": "Detects exposed Analytics user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/user-dump-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-analytics-03",
+    "name": "Analytics User Dump Exposure #3",
+    "description": "Detects exposed Analytics user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/analytics/user-dump-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-analytics-04",
+    "name": "Analytics User Dump Exposure #4",
+    "description": "Detects exposed Analytics user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/user-dump-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-analytics-05",
+    "name": "Analytics User Dump Exposure #5",
+    "description": "Detects exposed Analytics user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/user-dump-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-analytics-01",
+    "name": "Analytics Billing Export Exposure #1",
+    "description": "Identifies Analytics billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/billing-export-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-analytics-02",
+    "name": "Analytics Billing Export Exposure #2",
+    "description": "Identifies Analytics billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/billing-export-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-analytics-03",
+    "name": "Analytics Billing Export Exposure #3",
+    "description": "Identifies Analytics billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/analytics/billing-export-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-analytics-04",
+    "name": "Analytics Billing Export Exposure #4",
+    "description": "Identifies Analytics billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/billing-export-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-analytics-05",
+    "name": "Analytics Billing Export Exposure #5",
+    "description": "Identifies Analytics billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/billing-export-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-analytics-01",
+    "name": "Analytics Webhook Registry Leak #1",
+    "description": "Detects leaked Analytics webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/webhooks-registry-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-analytics-02",
+    "name": "Analytics Webhook Registry Leak #2",
+    "description": "Detects leaked Analytics webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/webhooks-registry-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-analytics-03",
+    "name": "Analytics Webhook Registry Leak #3",
+    "description": "Detects leaked Analytics webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/webhooks-registry-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-analytics-04",
+    "name": "Analytics Webhook Registry Leak #4",
+    "description": "Detects leaked Analytics webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/webhooks-registry-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-analytics-05",
+    "name": "Analytics Webhook Registry Leak #5",
+    "description": "Detects leaked Analytics webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/webhooks-registry-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-analytics-01",
+    "name": "Analytics Telemetry Snapshot Exposure #1",
+    "description": "Surfaces exposed Analytics telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/telemetry-snapshot-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-analytics-02",
+    "name": "Analytics Telemetry Snapshot Exposure #2",
+    "description": "Surfaces exposed Analytics telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/telemetry-snapshot-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-analytics-03",
+    "name": "Analytics Telemetry Snapshot Exposure #3",
+    "description": "Surfaces exposed Analytics telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/analytics/telemetry-snapshot-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-analytics-04",
+    "name": "Analytics Telemetry Snapshot Exposure #4",
+    "description": "Surfaces exposed Analytics telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/telemetry-snapshot-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-analytics-05",
+    "name": "Analytics Telemetry Snapshot Exposure #5",
+    "description": "Surfaces exposed Analytics telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/telemetry-snapshot-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-analytics-01",
+    "name": "Analytics Debug Trace Log Leak #1",
+    "description": "Detects leaked Analytics debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/debug-trace-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-analytics-02",
+    "name": "Analytics Debug Trace Log Leak #2",
+    "description": "Detects leaked Analytics debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/debug-trace-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-analytics-03",
+    "name": "Analytics Debug Trace Log Leak #3",
+    "description": "Detects leaked Analytics debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/analytics/debug-trace-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-analytics-04",
+    "name": "Analytics Debug Trace Log Leak #4",
+    "description": "Detects leaked Analytics debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/debug-trace-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-analytics-05",
+    "name": "Analytics Debug Trace Log Leak #5",
+    "description": "Detects leaked Analytics debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/debug-trace-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-analytics-01",
+    "name": "Analytics Database Backup Exposure #1",
+    "description": "Finds exposed Analytics database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/db-backup-01.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-analytics-02",
+    "name": "Analytics Database Backup Exposure #2",
+    "description": "Finds exposed Analytics database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/db-backup-02.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-analytics-03",
+    "name": "Analytics Database Backup Exposure #3",
+    "description": "Finds exposed Analytics database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/db-backup-03.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-analytics-04",
+    "name": "Analytics Database Backup Exposure #4",
+    "description": "Finds exposed Analytics database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/db-backup-04.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-analytics-05",
+    "name": "Analytics Database Backup Exposure #5",
+    "description": "Finds exposed Analytics database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/db-backup-05.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-analytics-01",
+    "name": "Analytics Compliance Report Leak #1",
+    "description": "Detects leaked Analytics compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/compliance-report-01.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-analytics-02",
+    "name": "Analytics Compliance Report Leak #2",
+    "description": "Detects leaked Analytics compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/compliance-report-02.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-analytics-03",
+    "name": "Analytics Compliance Report Leak #3",
+    "description": "Detects leaked Analytics compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/analytics/compliance-report-03.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-analytics-04",
+    "name": "Analytics Compliance Report Leak #4",
+    "description": "Detects leaked Analytics compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/compliance-report-04.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-analytics-05",
+    "name": "Analytics Compliance Report Leak #5",
+    "description": "Detects leaked Analytics compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/compliance-report-05.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-audit-01",
+    "name": "Audit Token Cache Dump #1",
+    "description": "Detects exposed Audit token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/token-cache-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-audit-02",
+    "name": "Audit Token Cache Dump #2",
+    "description": "Detects exposed Audit token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/token-cache-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-audit-03",
+    "name": "Audit Token Cache Dump #3",
+    "description": "Detects exposed Audit token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/token-cache-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-audit-04",
+    "name": "Audit Token Cache Dump #4",
+    "description": "Detects exposed Audit token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/token-cache-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-audit-05",
+    "name": "Audit Token Cache Dump #5",
+    "description": "Detects exposed Audit token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/token-cache-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-audit-01",
+    "name": "Audit Session Ledger Leak #1",
+    "description": "Catches leaked Audit session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/sessions-ledger-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-audit-02",
+    "name": "Audit Session Ledger Leak #2",
+    "description": "Catches leaked Audit session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/sessions-ledger-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-audit-03",
+    "name": "Audit Session Ledger Leak #3",
+    "description": "Catches leaked Audit session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/sessions-ledger-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-audit-04",
+    "name": "Audit Session Ledger Leak #4",
+    "description": "Catches leaked Audit session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/sessions-ledger-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-audit-05",
+    "name": "Audit Session Ledger Leak #5",
+    "description": "Catches leaked Audit session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/sessions-ledger-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-audit-01",
+    "name": "Audit Config Export Exposure #1",
+    "description": "Finds world-readable Audit configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/config-export-01.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-audit-02",
+    "name": "Audit Config Export Exposure #2",
+    "description": "Finds world-readable Audit configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/config-export-02.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-audit-03",
+    "name": "Audit Config Export Exposure #3",
+    "description": "Finds world-readable Audit configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/config-export-03.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-audit-04",
+    "name": "Audit Config Export Exposure #4",
+    "description": "Finds world-readable Audit configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/config-export-04.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-audit-05",
+    "name": "Audit Config Export Exposure #5",
+    "description": "Finds world-readable Audit configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/config-export-05.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-audit-01",
+    "name": "Audit User Dump Exposure #1",
+    "description": "Detects exposed Audit user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/user-dump-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-audit-02",
+    "name": "Audit User Dump Exposure #2",
+    "description": "Detects exposed Audit user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/user-dump-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-audit-03",
+    "name": "Audit User Dump Exposure #3",
+    "description": "Detects exposed Audit user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/audit/user-dump-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-audit-04",
+    "name": "Audit User Dump Exposure #4",
+    "description": "Detects exposed Audit user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/user-dump-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-audit-05",
+    "name": "Audit User Dump Exposure #5",
+    "description": "Detects exposed Audit user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/user-dump-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-audit-01",
+    "name": "Audit Billing Export Exposure #1",
+    "description": "Identifies Audit billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/billing-export-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-audit-02",
+    "name": "Audit Billing Export Exposure #2",
+    "description": "Identifies Audit billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/billing-export-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-audit-03",
+    "name": "Audit Billing Export Exposure #3",
+    "description": "Identifies Audit billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/audit/billing-export-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-audit-04",
+    "name": "Audit Billing Export Exposure #4",
+    "description": "Identifies Audit billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/billing-export-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-audit-05",
+    "name": "Audit Billing Export Exposure #5",
+    "description": "Identifies Audit billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/billing-export-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-audit-01",
+    "name": "Audit Webhook Registry Leak #1",
+    "description": "Detects leaked Audit webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/webhooks-registry-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-audit-02",
+    "name": "Audit Webhook Registry Leak #2",
+    "description": "Detects leaked Audit webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/webhooks-registry-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-audit-03",
+    "name": "Audit Webhook Registry Leak #3",
+    "description": "Detects leaked Audit webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/webhooks-registry-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-audit-04",
+    "name": "Audit Webhook Registry Leak #4",
+    "description": "Detects leaked Audit webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/webhooks-registry-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-audit-05",
+    "name": "Audit Webhook Registry Leak #5",
+    "description": "Detects leaked Audit webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/webhooks-registry-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-audit-01",
+    "name": "Audit Telemetry Snapshot Exposure #1",
+    "description": "Surfaces exposed Audit telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/telemetry-snapshot-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-audit-02",
+    "name": "Audit Telemetry Snapshot Exposure #2",
+    "description": "Surfaces exposed Audit telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/telemetry-snapshot-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-audit-03",
+    "name": "Audit Telemetry Snapshot Exposure #3",
+    "description": "Surfaces exposed Audit telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/audit/telemetry-snapshot-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-audit-04",
+    "name": "Audit Telemetry Snapshot Exposure #4",
+    "description": "Surfaces exposed Audit telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/telemetry-snapshot-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-audit-05",
+    "name": "Audit Telemetry Snapshot Exposure #5",
+    "description": "Surfaces exposed Audit telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/telemetry-snapshot-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-audit-01",
+    "name": "Audit Debug Trace Log Leak #1",
+    "description": "Detects leaked Audit debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/debug-trace-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-audit-02",
+    "name": "Audit Debug Trace Log Leak #2",
+    "description": "Detects leaked Audit debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/debug-trace-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-audit-03",
+    "name": "Audit Debug Trace Log Leak #3",
+    "description": "Detects leaked Audit debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/audit/debug-trace-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-audit-04",
+    "name": "Audit Debug Trace Log Leak #4",
+    "description": "Detects leaked Audit debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/debug-trace-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-audit-05",
+    "name": "Audit Debug Trace Log Leak #5",
+    "description": "Detects leaked Audit debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/debug-trace-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-audit-01",
+    "name": "Audit Database Backup Exposure #1",
+    "description": "Finds exposed Audit database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/db-backup-01.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-audit-02",
+    "name": "Audit Database Backup Exposure #2",
+    "description": "Finds exposed Audit database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/db-backup-02.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-audit-03",
+    "name": "Audit Database Backup Exposure #3",
+    "description": "Finds exposed Audit database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/db-backup-03.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-audit-04",
+    "name": "Audit Database Backup Exposure #4",
+    "description": "Finds exposed Audit database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/db-backup-04.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-audit-05",
+    "name": "Audit Database Backup Exposure #5",
+    "description": "Finds exposed Audit database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/db-backup-05.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-audit-01",
+    "name": "Audit Compliance Report Leak #1",
+    "description": "Detects leaked Audit compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/compliance-report-01.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-audit-02",
+    "name": "Audit Compliance Report Leak #2",
+    "description": "Detects leaked Audit compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/compliance-report-02.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-audit-03",
+    "name": "Audit Compliance Report Leak #3",
+    "description": "Detects leaked Audit compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/audit/compliance-report-03.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-audit-04",
+    "name": "Audit Compliance Report Leak #4",
+    "description": "Detects leaked Audit compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/compliance-report-04.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-audit-05",
+    "name": "Audit Compliance Report Leak #5",
+    "description": "Detects leaked Audit compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/compliance-report-05.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-billing-01",
+    "name": "Billing Token Cache Dump #1",
+    "description": "Detects exposed Billing token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/token-cache-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-billing-02",
+    "name": "Billing Token Cache Dump #2",
+    "description": "Detects exposed Billing token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/token-cache-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-billing-03",
+    "name": "Billing Token Cache Dump #3",
+    "description": "Detects exposed Billing token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/token-cache-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-billing-04",
+    "name": "Billing Token Cache Dump #4",
+    "description": "Detects exposed Billing token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/token-cache-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-billing-05",
+    "name": "Billing Token Cache Dump #5",
+    "description": "Detects exposed Billing token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/token-cache-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-billing-01",
+    "name": "Billing Session Ledger Leak #1",
+    "description": "Catches leaked Billing session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/sessions-ledger-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-billing-02",
+    "name": "Billing Session Ledger Leak #2",
+    "description": "Catches leaked Billing session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/sessions-ledger-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-billing-03",
+    "name": "Billing Session Ledger Leak #3",
+    "description": "Catches leaked Billing session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/sessions-ledger-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-billing-04",
+    "name": "Billing Session Ledger Leak #4",
+    "description": "Catches leaked Billing session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/sessions-ledger-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-billing-05",
+    "name": "Billing Session Ledger Leak #5",
+    "description": "Catches leaked Billing session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/sessions-ledger-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-billing-01",
+    "name": "Billing Config Export Exposure #1",
+    "description": "Finds world-readable Billing configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/config-export-01.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-billing-02",
+    "name": "Billing Config Export Exposure #2",
+    "description": "Finds world-readable Billing configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/config-export-02.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-billing-03",
+    "name": "Billing Config Export Exposure #3",
+    "description": "Finds world-readable Billing configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/config-export-03.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-billing-04",
+    "name": "Billing Config Export Exposure #4",
+    "description": "Finds world-readable Billing configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/config-export-04.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-billing-05",
+    "name": "Billing Config Export Exposure #5",
+    "description": "Finds world-readable Billing configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/config-export-05.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-billing-01",
+    "name": "Billing User Dump Exposure #1",
+    "description": "Detects exposed Billing user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/user-dump-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-billing-02",
+    "name": "Billing User Dump Exposure #2",
+    "description": "Detects exposed Billing user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/user-dump-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-billing-03",
+    "name": "Billing User Dump Exposure #3",
+    "description": "Detects exposed Billing user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/billing/user-dump-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-billing-04",
+    "name": "Billing User Dump Exposure #4",
+    "description": "Detects exposed Billing user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/user-dump-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-billing-05",
+    "name": "Billing User Dump Exposure #5",
+    "description": "Detects exposed Billing user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/user-dump-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-billing-01",
+    "name": "Billing Billing Export Exposure #1",
+    "description": "Identifies Billing billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/billing-export-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-billing-02",
+    "name": "Billing Billing Export Exposure #2",
+    "description": "Identifies Billing billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/billing-export-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-billing-03",
+    "name": "Billing Billing Export Exposure #3",
+    "description": "Identifies Billing billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/billing/billing-export-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-billing-04",
+    "name": "Billing Billing Export Exposure #4",
+    "description": "Identifies Billing billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/billing-export-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-billing-05",
+    "name": "Billing Billing Export Exposure #5",
+    "description": "Identifies Billing billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/billing-export-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-billing-01",
+    "name": "Billing Webhook Registry Leak #1",
+    "description": "Detects leaked Billing webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/webhooks-registry-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-billing-02",
+    "name": "Billing Webhook Registry Leak #2",
+    "description": "Detects leaked Billing webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/webhooks-registry-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-billing-03",
+    "name": "Billing Webhook Registry Leak #3",
+    "description": "Detects leaked Billing webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/webhooks-registry-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-billing-04",
+    "name": "Billing Webhook Registry Leak #4",
+    "description": "Detects leaked Billing webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/webhooks-registry-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-billing-05",
+    "name": "Billing Webhook Registry Leak #5",
+    "description": "Detects leaked Billing webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/webhooks-registry-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-billing-01",
+    "name": "Billing Telemetry Snapshot Exposure #1",
+    "description": "Surfaces exposed Billing telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/telemetry-snapshot-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-billing-02",
+    "name": "Billing Telemetry Snapshot Exposure #2",
+    "description": "Surfaces exposed Billing telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/telemetry-snapshot-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-billing-03",
+    "name": "Billing Telemetry Snapshot Exposure #3",
+    "description": "Surfaces exposed Billing telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/billing/telemetry-snapshot-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-billing-04",
+    "name": "Billing Telemetry Snapshot Exposure #4",
+    "description": "Surfaces exposed Billing telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/telemetry-snapshot-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-billing-05",
+    "name": "Billing Telemetry Snapshot Exposure #5",
+    "description": "Surfaces exposed Billing telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/telemetry-snapshot-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-billing-01",
+    "name": "Billing Debug Trace Log Leak #1",
+    "description": "Detects leaked Billing debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/debug-trace-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-billing-02",
+    "name": "Billing Debug Trace Log Leak #2",
+    "description": "Detects leaked Billing debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/debug-trace-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-billing-03",
+    "name": "Billing Debug Trace Log Leak #3",
+    "description": "Detects leaked Billing debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/billing/debug-trace-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-billing-04",
+    "name": "Billing Debug Trace Log Leak #4",
+    "description": "Detects leaked Billing debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/debug-trace-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-billing-05",
+    "name": "Billing Debug Trace Log Leak #5",
+    "description": "Detects leaked Billing debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/debug-trace-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-billing-01",
+    "name": "Billing Database Backup Exposure #1",
+    "description": "Finds exposed Billing database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/db-backup-01.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-billing-02",
+    "name": "Billing Database Backup Exposure #2",
+    "description": "Finds exposed Billing database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/db-backup-02.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-billing-03",
+    "name": "Billing Database Backup Exposure #3",
+    "description": "Finds exposed Billing database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/db-backup-03.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-billing-04",
+    "name": "Billing Database Backup Exposure #4",
+    "description": "Finds exposed Billing database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/db-backup-04.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-billing-05",
+    "name": "Billing Database Backup Exposure #5",
+    "description": "Finds exposed Billing database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/db-backup-05.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-billing-01",
+    "name": "Billing Compliance Report Leak #1",
+    "description": "Detects leaked Billing compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/compliance-report-01.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-billing-02",
+    "name": "Billing Compliance Report Leak #2",
+    "description": "Detects leaked Billing compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/compliance-report-02.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-billing-03",
+    "name": "Billing Compliance Report Leak #3",
+    "description": "Detects leaked Billing compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/billing/compliance-report-03.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-billing-04",
+    "name": "Billing Compliance Report Leak #4",
+    "description": "Detects leaked Billing compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/compliance-report-04.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-billing-05",
+    "name": "Billing Compliance Report Leak #5",
+    "description": "Detects leaked Billing compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/compliance-report-05.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-business-intelligence-01",
+    "name": "Business Intelligence Token Cache Dump #1",
+    "description": "Detects exposed Business Intelligence token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/token-cache-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-business-intelligence-02",
+    "name": "Business Intelligence Token Cache Dump #2",
+    "description": "Detects exposed Business Intelligence token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/token-cache-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-business-intelligence-03",
+    "name": "Business Intelligence Token Cache Dump #3",
+    "description": "Detects exposed Business Intelligence token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/token-cache-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-business-intelligence-04",
+    "name": "Business Intelligence Token Cache Dump #4",
+    "description": "Detects exposed Business Intelligence token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/token-cache-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-business-intelligence-05",
+    "name": "Business Intelligence Token Cache Dump #5",
+    "description": "Detects exposed Business Intelligence token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/token-cache-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-business-intelligence-01",
+    "name": "Business Intelligence Session Ledger Leak #1",
+    "description": "Catches leaked Business Intelligence session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/sessions-ledger-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-business-intelligence-02",
+    "name": "Business Intelligence Session Ledger Leak #2",
+    "description": "Catches leaked Business Intelligence session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/sessions-ledger-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-business-intelligence-03",
+    "name": "Business Intelligence Session Ledger Leak #3",
+    "description": "Catches leaked Business Intelligence session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/sessions-ledger-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-business-intelligence-04",
+    "name": "Business Intelligence Session Ledger Leak #4",
+    "description": "Catches leaked Business Intelligence session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/sessions-ledger-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-business-intelligence-05",
+    "name": "Business Intelligence Session Ledger Leak #5",
+    "description": "Catches leaked Business Intelligence session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/sessions-ledger-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-business-intelligence-01",
+    "name": "Business Intelligence Config Export Exposure #1",
+    "description": "Finds world-readable Business Intelligence configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/config-export-01.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-business-intelligence-02",
+    "name": "Business Intelligence Config Export Exposure #2",
+    "description": "Finds world-readable Business Intelligence configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/config-export-02.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-business-intelligence-03",
+    "name": "Business Intelligence Config Export Exposure #3",
+    "description": "Finds world-readable Business Intelligence configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/config-export-03.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-business-intelligence-04",
+    "name": "Business Intelligence Config Export Exposure #4",
+    "description": "Finds world-readable Business Intelligence configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/config-export-04.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-business-intelligence-05",
+    "name": "Business Intelligence Config Export Exposure #5",
+    "description": "Finds world-readable Business Intelligence configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/config-export-05.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-business-intelligence-01",
+    "name": "Business Intelligence User Dump Exposure #1",
+    "description": "Detects exposed Business Intelligence user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/user-dump-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-business-intelligence-02",
+    "name": "Business Intelligence User Dump Exposure #2",
+    "description": "Detects exposed Business Intelligence user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/user-dump-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-business-intelligence-03",
+    "name": "Business Intelligence User Dump Exposure #3",
+    "description": "Detects exposed Business Intelligence user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/business-intelligence/user-dump-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-business-intelligence-04",
+    "name": "Business Intelligence User Dump Exposure #4",
+    "description": "Detects exposed Business Intelligence user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/user-dump-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-business-intelligence-05",
+    "name": "Business Intelligence User Dump Exposure #5",
+    "description": "Detects exposed Business Intelligence user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/user-dump-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-business-intelligence-01",
+    "name": "Business Intelligence Billing Export Exposure #1",
+    "description": "Identifies Business Intelligence billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/billing-export-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-business-intelligence-02",
+    "name": "Business Intelligence Billing Export Exposure #2",
+    "description": "Identifies Business Intelligence billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/billing-export-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-business-intelligence-03",
+    "name": "Business Intelligence Billing Export Exposure #3",
+    "description": "Identifies Business Intelligence billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/business-intelligence/billing-export-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-business-intelligence-04",
+    "name": "Business Intelligence Billing Export Exposure #4",
+    "description": "Identifies Business Intelligence billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/billing-export-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-business-intelligence-05",
+    "name": "Business Intelligence Billing Export Exposure #5",
+    "description": "Identifies Business Intelligence billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/billing-export-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-business-intelligence-01",
+    "name": "Business Intelligence Webhook Registry Leak #1",
+    "description": "Detects leaked Business Intelligence webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/webhooks-registry-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-business-intelligence-02",
+    "name": "Business Intelligence Webhook Registry Leak #2",
+    "description": "Detects leaked Business Intelligence webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/webhooks-registry-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-business-intelligence-03",
+    "name": "Business Intelligence Webhook Registry Leak #3",
+    "description": "Detects leaked Business Intelligence webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/webhooks-registry-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-business-intelligence-04",
+    "name": "Business Intelligence Webhook Registry Leak #4",
+    "description": "Detects leaked Business Intelligence webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/webhooks-registry-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-business-intelligence-05",
+    "name": "Business Intelligence Webhook Registry Leak #5",
+    "description": "Detects leaked Business Intelligence webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/webhooks-registry-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-business-intelligence-01",
+    "name": "Business Intelligence Telemetry Snapshot Exposure #1",
+    "description": "Surfaces exposed Business Intelligence telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/telemetry-snapshot-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-business-intelligence-02",
+    "name": "Business Intelligence Telemetry Snapshot Exposure #2",
+    "description": "Surfaces exposed Business Intelligence telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/telemetry-snapshot-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-business-intelligence-03",
+    "name": "Business Intelligence Telemetry Snapshot Exposure #3",
+    "description": "Surfaces exposed Business Intelligence telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/business-intelligence/telemetry-snapshot-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-business-intelligence-04",
+    "name": "Business Intelligence Telemetry Snapshot Exposure #4",
+    "description": "Surfaces exposed Business Intelligence telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/telemetry-snapshot-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-business-intelligence-05",
+    "name": "Business Intelligence Telemetry Snapshot Exposure #5",
+    "description": "Surfaces exposed Business Intelligence telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/telemetry-snapshot-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-business-intelligence-01",
+    "name": "Business Intelligence Debug Trace Log Leak #1",
+    "description": "Detects leaked Business Intelligence debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/debug-trace-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-business-intelligence-02",
+    "name": "Business Intelligence Debug Trace Log Leak #2",
+    "description": "Detects leaked Business Intelligence debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/debug-trace-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-business-intelligence-03",
+    "name": "Business Intelligence Debug Trace Log Leak #3",
+    "description": "Detects leaked Business Intelligence debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/business-intelligence/debug-trace-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-business-intelligence-04",
+    "name": "Business Intelligence Debug Trace Log Leak #4",
+    "description": "Detects leaked Business Intelligence debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/debug-trace-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-business-intelligence-05",
+    "name": "Business Intelligence Debug Trace Log Leak #5",
+    "description": "Detects leaked Business Intelligence debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/debug-trace-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-business-intelligence-01",
+    "name": "Business Intelligence Database Backup Exposure #1",
+    "description": "Finds exposed Business Intelligence database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/db-backup-01.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-business-intelligence-02",
+    "name": "Business Intelligence Database Backup Exposure #2",
+    "description": "Finds exposed Business Intelligence database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/db-backup-02.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-business-intelligence-03",
+    "name": "Business Intelligence Database Backup Exposure #3",
+    "description": "Finds exposed Business Intelligence database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/db-backup-03.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-business-intelligence-04",
+    "name": "Business Intelligence Database Backup Exposure #4",
+    "description": "Finds exposed Business Intelligence database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/db-backup-04.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-business-intelligence-05",
+    "name": "Business Intelligence Database Backup Exposure #5",
+    "description": "Finds exposed Business Intelligence database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/db-backup-05.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-business-intelligence-01",
+    "name": "Business Intelligence Compliance Report Leak #1",
+    "description": "Detects leaked Business Intelligence compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/compliance-report-01.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-business-intelligence-02",
+    "name": "Business Intelligence Compliance Report Leak #2",
+    "description": "Detects leaked Business Intelligence compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/compliance-report-02.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-business-intelligence-03",
+    "name": "Business Intelligence Compliance Report Leak #3",
+    "description": "Detects leaked Business Intelligence compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/business-intelligence/compliance-report-03.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-business-intelligence-04",
+    "name": "Business Intelligence Compliance Report Leak #4",
+    "description": "Detects leaked Business Intelligence compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/compliance-report-04.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-business-intelligence-05",
+    "name": "Business Intelligence Compliance Report Leak #5",
+    "description": "Detects leaked Business Intelligence compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/compliance-report-05.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-cloud-ops-01",
+    "name": "Cloud Ops Token Cache Dump #1",
+    "description": "Detects exposed Cloud Ops token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/token-cache-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-cloud-ops-02",
+    "name": "Cloud Ops Token Cache Dump #2",
+    "description": "Detects exposed Cloud Ops token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/token-cache-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-cloud-ops-03",
+    "name": "Cloud Ops Token Cache Dump #3",
+    "description": "Detects exposed Cloud Ops token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/token-cache-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-cloud-ops-04",
+    "name": "Cloud Ops Token Cache Dump #4",
+    "description": "Detects exposed Cloud Ops token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/token-cache-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-cloud-ops-05",
+    "name": "Cloud Ops Token Cache Dump #5",
+    "description": "Detects exposed Cloud Ops token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/token-cache-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-cloud-ops-01",
+    "name": "Cloud Ops Session Ledger Leak #1",
+    "description": "Catches leaked Cloud Ops session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/sessions-ledger-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-cloud-ops-02",
+    "name": "Cloud Ops Session Ledger Leak #2",
+    "description": "Catches leaked Cloud Ops session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/sessions-ledger-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-cloud-ops-03",
+    "name": "Cloud Ops Session Ledger Leak #3",
+    "description": "Catches leaked Cloud Ops session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/sessions-ledger-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-cloud-ops-04",
+    "name": "Cloud Ops Session Ledger Leak #4",
+    "description": "Catches leaked Cloud Ops session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/sessions-ledger-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-cloud-ops-05",
+    "name": "Cloud Ops Session Ledger Leak #5",
+    "description": "Catches leaked Cloud Ops session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/sessions-ledger-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-cloud-ops-01",
+    "name": "Cloud Ops Config Export Exposure #1",
+    "description": "Finds world-readable Cloud Ops configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/config-export-01.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-cloud-ops-02",
+    "name": "Cloud Ops Config Export Exposure #2",
+    "description": "Finds world-readable Cloud Ops configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/config-export-02.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-cloud-ops-03",
+    "name": "Cloud Ops Config Export Exposure #3",
+    "description": "Finds world-readable Cloud Ops configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/config-export-03.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-cloud-ops-04",
+    "name": "Cloud Ops Config Export Exposure #4",
+    "description": "Finds world-readable Cloud Ops configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/config-export-04.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-cloud-ops-05",
+    "name": "Cloud Ops Config Export Exposure #5",
+    "description": "Finds world-readable Cloud Ops configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/config-export-05.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-cloud-ops-01",
+    "name": "Cloud Ops User Dump Exposure #1",
+    "description": "Detects exposed Cloud Ops user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/user-dump-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-cloud-ops-02",
+    "name": "Cloud Ops User Dump Exposure #2",
+    "description": "Detects exposed Cloud Ops user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/user-dump-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-cloud-ops-03",
+    "name": "Cloud Ops User Dump Exposure #3",
+    "description": "Detects exposed Cloud Ops user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/cloud-ops/user-dump-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-cloud-ops-04",
+    "name": "Cloud Ops User Dump Exposure #4",
+    "description": "Detects exposed Cloud Ops user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/user-dump-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-cloud-ops-05",
+    "name": "Cloud Ops User Dump Exposure #5",
+    "description": "Detects exposed Cloud Ops user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/user-dump-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-cloud-ops-01",
+    "name": "Cloud Ops Billing Export Exposure #1",
+    "description": "Identifies Cloud Ops billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/billing-export-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-cloud-ops-02",
+    "name": "Cloud Ops Billing Export Exposure #2",
+    "description": "Identifies Cloud Ops billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/billing-export-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-cloud-ops-03",
+    "name": "Cloud Ops Billing Export Exposure #3",
+    "description": "Identifies Cloud Ops billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/cloud-ops/billing-export-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-cloud-ops-04",
+    "name": "Cloud Ops Billing Export Exposure #4",
+    "description": "Identifies Cloud Ops billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/billing-export-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-cloud-ops-05",
+    "name": "Cloud Ops Billing Export Exposure #5",
+    "description": "Identifies Cloud Ops billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/billing-export-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-cloud-ops-01",
+    "name": "Cloud Ops Webhook Registry Leak #1",
+    "description": "Detects leaked Cloud Ops webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/webhooks-registry-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-cloud-ops-02",
+    "name": "Cloud Ops Webhook Registry Leak #2",
+    "description": "Detects leaked Cloud Ops webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/webhooks-registry-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-cloud-ops-03",
+    "name": "Cloud Ops Webhook Registry Leak #3",
+    "description": "Detects leaked Cloud Ops webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/webhooks-registry-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-cloud-ops-04",
+    "name": "Cloud Ops Webhook Registry Leak #4",
+    "description": "Detects leaked Cloud Ops webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/webhooks-registry-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-cloud-ops-05",
+    "name": "Cloud Ops Webhook Registry Leak #5",
+    "description": "Detects leaked Cloud Ops webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/webhooks-registry-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-cloud-ops-01",
+    "name": "Cloud Ops Telemetry Snapshot Exposure #1",
+    "description": "Surfaces exposed Cloud Ops telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/telemetry-snapshot-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-cloud-ops-02",
+    "name": "Cloud Ops Telemetry Snapshot Exposure #2",
+    "description": "Surfaces exposed Cloud Ops telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/telemetry-snapshot-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-cloud-ops-03",
+    "name": "Cloud Ops Telemetry Snapshot Exposure #3",
+    "description": "Surfaces exposed Cloud Ops telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/cloud-ops/telemetry-snapshot-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-cloud-ops-04",
+    "name": "Cloud Ops Telemetry Snapshot Exposure #4",
+    "description": "Surfaces exposed Cloud Ops telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/telemetry-snapshot-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-cloud-ops-05",
+    "name": "Cloud Ops Telemetry Snapshot Exposure #5",
+    "description": "Surfaces exposed Cloud Ops telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/telemetry-snapshot-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-cloud-ops-01",
+    "name": "Cloud Ops Debug Trace Log Leak #1",
+    "description": "Detects leaked Cloud Ops debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/debug-trace-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-cloud-ops-02",
+    "name": "Cloud Ops Debug Trace Log Leak #2",
+    "description": "Detects leaked Cloud Ops debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/debug-trace-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-cloud-ops-03",
+    "name": "Cloud Ops Debug Trace Log Leak #3",
+    "description": "Detects leaked Cloud Ops debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/cloud-ops/debug-trace-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-cloud-ops-04",
+    "name": "Cloud Ops Debug Trace Log Leak #4",
+    "description": "Detects leaked Cloud Ops debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/debug-trace-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-cloud-ops-05",
+    "name": "Cloud Ops Debug Trace Log Leak #5",
+    "description": "Detects leaked Cloud Ops debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/debug-trace-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-cloud-ops-01",
+    "name": "Cloud Ops Database Backup Exposure #1",
+    "description": "Finds exposed Cloud Ops database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/db-backup-01.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-cloud-ops-02",
+    "name": "Cloud Ops Database Backup Exposure #2",
+    "description": "Finds exposed Cloud Ops database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/db-backup-02.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-cloud-ops-03",
+    "name": "Cloud Ops Database Backup Exposure #3",
+    "description": "Finds exposed Cloud Ops database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/db-backup-03.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-cloud-ops-04",
+    "name": "Cloud Ops Database Backup Exposure #4",
+    "description": "Finds exposed Cloud Ops database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/db-backup-04.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-cloud-ops-05",
+    "name": "Cloud Ops Database Backup Exposure #5",
+    "description": "Finds exposed Cloud Ops database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/db-backup-05.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-cloud-ops-01",
+    "name": "Cloud Ops Compliance Report Leak #1",
+    "description": "Detects leaked Cloud Ops compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/compliance-report-01.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-cloud-ops-02",
+    "name": "Cloud Ops Compliance Report Leak #2",
+    "description": "Detects leaked Cloud Ops compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/compliance-report-02.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-cloud-ops-03",
+    "name": "Cloud Ops Compliance Report Leak #3",
+    "description": "Detects leaked Cloud Ops compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/cloud-ops/compliance-report-03.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-cloud-ops-04",
+    "name": "Cloud Ops Compliance Report Leak #4",
+    "description": "Detects leaked Cloud Ops compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/compliance-report-04.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-cloud-ops-05",
+    "name": "Cloud Ops Compliance Report Leak #5",
+    "description": "Detects leaked Cloud Ops compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/compliance-report-05.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-collaboration-01",
+    "name": "Collaboration Token Cache Dump #1",
+    "description": "Detects exposed Collaboration token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/token-cache-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-collaboration-02",
+    "name": "Collaboration Token Cache Dump #2",
+    "description": "Detects exposed Collaboration token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/token-cache-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-collaboration-03",
+    "name": "Collaboration Token Cache Dump #3",
+    "description": "Detects exposed Collaboration token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/token-cache-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-collaboration-04",
+    "name": "Collaboration Token Cache Dump #4",
+    "description": "Detects exposed Collaboration token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/token-cache-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-collaboration-05",
+    "name": "Collaboration Token Cache Dump #5",
+    "description": "Detects exposed Collaboration token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/token-cache-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-collaboration-01",
+    "name": "Collaboration Session Ledger Leak #1",
+    "description": "Catches leaked Collaboration session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/sessions-ledger-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-collaboration-02",
+    "name": "Collaboration Session Ledger Leak #2",
+    "description": "Catches leaked Collaboration session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/sessions-ledger-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-collaboration-03",
+    "name": "Collaboration Session Ledger Leak #3",
+    "description": "Catches leaked Collaboration session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/sessions-ledger-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-collaboration-04",
+    "name": "Collaboration Session Ledger Leak #4",
+    "description": "Catches leaked Collaboration session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/sessions-ledger-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-collaboration-05",
+    "name": "Collaboration Session Ledger Leak #5",
+    "description": "Catches leaked Collaboration session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/sessions-ledger-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-collaboration-01",
+    "name": "Collaboration Config Export Exposure #1",
+    "description": "Finds world-readable Collaboration configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/config-export-01.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-collaboration-02",
+    "name": "Collaboration Config Export Exposure #2",
+    "description": "Finds world-readable Collaboration configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/config-export-02.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-collaboration-03",
+    "name": "Collaboration Config Export Exposure #3",
+    "description": "Finds world-readable Collaboration configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/config-export-03.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-collaboration-04",
+    "name": "Collaboration Config Export Exposure #4",
+    "description": "Finds world-readable Collaboration configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/config-export-04.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-collaboration-05",
+    "name": "Collaboration Config Export Exposure #5",
+    "description": "Finds world-readable Collaboration configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/config-export-05.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-collaboration-01",
+    "name": "Collaboration User Dump Exposure #1",
+    "description": "Detects exposed Collaboration user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/user-dump-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-collaboration-02",
+    "name": "Collaboration User Dump Exposure #2",
+    "description": "Detects exposed Collaboration user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/user-dump-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-collaboration-03",
+    "name": "Collaboration User Dump Exposure #3",
+    "description": "Detects exposed Collaboration user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/collaboration/user-dump-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-collaboration-04",
+    "name": "Collaboration User Dump Exposure #4",
+    "description": "Detects exposed Collaboration user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/user-dump-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-collaboration-05",
+    "name": "Collaboration User Dump Exposure #5",
+    "description": "Detects exposed Collaboration user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/user-dump-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-collaboration-01",
+    "name": "Collaboration Billing Export Exposure #1",
+    "description": "Identifies Collaboration billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/billing-export-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-collaboration-02",
+    "name": "Collaboration Billing Export Exposure #2",
+    "description": "Identifies Collaboration billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/billing-export-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-collaboration-03",
+    "name": "Collaboration Billing Export Exposure #3",
+    "description": "Identifies Collaboration billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/collaboration/billing-export-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-collaboration-04",
+    "name": "Collaboration Billing Export Exposure #4",
+    "description": "Identifies Collaboration billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/billing-export-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-collaboration-05",
+    "name": "Collaboration Billing Export Exposure #5",
+    "description": "Identifies Collaboration billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/billing-export-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-collaboration-01",
+    "name": "Collaboration Webhook Registry Leak #1",
+    "description": "Detects leaked Collaboration webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/webhooks-registry-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-collaboration-02",
+    "name": "Collaboration Webhook Registry Leak #2",
+    "description": "Detects leaked Collaboration webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/webhooks-registry-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-collaboration-03",
+    "name": "Collaboration Webhook Registry Leak #3",
+    "description": "Detects leaked Collaboration webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/webhooks-registry-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-collaboration-04",
+    "name": "Collaboration Webhook Registry Leak #4",
+    "description": "Detects leaked Collaboration webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/webhooks-registry-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-collaboration-05",
+    "name": "Collaboration Webhook Registry Leak #5",
+    "description": "Detects leaked Collaboration webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/webhooks-registry-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-collaboration-01",
+    "name": "Collaboration Telemetry Snapshot Exposure #1",
+    "description": "Surfaces exposed Collaboration telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/telemetry-snapshot-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-collaboration-02",
+    "name": "Collaboration Telemetry Snapshot Exposure #2",
+    "description": "Surfaces exposed Collaboration telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/telemetry-snapshot-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-collaboration-03",
+    "name": "Collaboration Telemetry Snapshot Exposure #3",
+    "description": "Surfaces exposed Collaboration telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/collaboration/telemetry-snapshot-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-collaboration-04",
+    "name": "Collaboration Telemetry Snapshot Exposure #4",
+    "description": "Surfaces exposed Collaboration telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/telemetry-snapshot-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-collaboration-05",
+    "name": "Collaboration Telemetry Snapshot Exposure #5",
+    "description": "Surfaces exposed Collaboration telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/telemetry-snapshot-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-collaboration-01",
+    "name": "Collaboration Debug Trace Log Leak #1",
+    "description": "Detects leaked Collaboration debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/debug-trace-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-collaboration-02",
+    "name": "Collaboration Debug Trace Log Leak #2",
+    "description": "Detects leaked Collaboration debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/debug-trace-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-collaboration-03",
+    "name": "Collaboration Debug Trace Log Leak #3",
+    "description": "Detects leaked Collaboration debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/collaboration/debug-trace-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-collaboration-04",
+    "name": "Collaboration Debug Trace Log Leak #4",
+    "description": "Detects leaked Collaboration debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/debug-trace-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-collaboration-05",
+    "name": "Collaboration Debug Trace Log Leak #5",
+    "description": "Detects leaked Collaboration debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/debug-trace-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-collaboration-01",
+    "name": "Collaboration Database Backup Exposure #1",
+    "description": "Finds exposed Collaboration database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/db-backup-01.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-collaboration-02",
+    "name": "Collaboration Database Backup Exposure #2",
+    "description": "Finds exposed Collaboration database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/db-backup-02.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-collaboration-03",
+    "name": "Collaboration Database Backup Exposure #3",
+    "description": "Finds exposed Collaboration database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/db-backup-03.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-collaboration-04",
+    "name": "Collaboration Database Backup Exposure #4",
+    "description": "Finds exposed Collaboration database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/db-backup-04.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-collaboration-05",
+    "name": "Collaboration Database Backup Exposure #5",
+    "description": "Finds exposed Collaboration database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/db-backup-05.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-collaboration-01",
+    "name": "Collaboration Compliance Report Leak #1",
+    "description": "Detects leaked Collaboration compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/compliance-report-01.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-collaboration-02",
+    "name": "Collaboration Compliance Report Leak #2",
+    "description": "Detects leaked Collaboration compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/compliance-report-02.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-collaboration-03",
+    "name": "Collaboration Compliance Report Leak #3",
+    "description": "Detects leaked Collaboration compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/collaboration/compliance-report-03.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-collaboration-04",
+    "name": "Collaboration Compliance Report Leak #4",
+    "description": "Detects leaked Collaboration compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/compliance-report-04.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-collaboration-05",
+    "name": "Collaboration Compliance Report Leak #5",
+    "description": "Detects leaked Collaboration compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/compliance-report-05.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-commerce-01",
+    "name": "Commerce Token Cache Dump #1",
+    "description": "Detects exposed Commerce token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/token-cache-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-commerce-02",
+    "name": "Commerce Token Cache Dump #2",
+    "description": "Detects exposed Commerce token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/token-cache-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-commerce-03",
+    "name": "Commerce Token Cache Dump #3",
+    "description": "Detects exposed Commerce token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/token-cache-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-commerce-04",
+    "name": "Commerce Token Cache Dump #4",
+    "description": "Detects exposed Commerce token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/token-cache-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-commerce-05",
+    "name": "Commerce Token Cache Dump #5",
+    "description": "Detects exposed Commerce token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/token-cache-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-commerce-01",
+    "name": "Commerce Session Ledger Leak #1",
+    "description": "Catches leaked Commerce session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/sessions-ledger-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-commerce-02",
+    "name": "Commerce Session Ledger Leak #2",
+    "description": "Catches leaked Commerce session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/sessions-ledger-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-commerce-03",
+    "name": "Commerce Session Ledger Leak #3",
+    "description": "Catches leaked Commerce session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/sessions-ledger-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-commerce-04",
+    "name": "Commerce Session Ledger Leak #4",
+    "description": "Catches leaked Commerce session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/sessions-ledger-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-commerce-05",
+    "name": "Commerce Session Ledger Leak #5",
+    "description": "Catches leaked Commerce session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/sessions-ledger-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-commerce-01",
+    "name": "Commerce Config Export Exposure #1",
+    "description": "Finds world-readable Commerce configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/config-export-01.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-commerce-02",
+    "name": "Commerce Config Export Exposure #2",
+    "description": "Finds world-readable Commerce configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/config-export-02.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-commerce-03",
+    "name": "Commerce Config Export Exposure #3",
+    "description": "Finds world-readable Commerce configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/config-export-03.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-commerce-04",
+    "name": "Commerce Config Export Exposure #4",
+    "description": "Finds world-readable Commerce configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/config-export-04.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-commerce-05",
+    "name": "Commerce Config Export Exposure #5",
+    "description": "Finds world-readable Commerce configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/config-export-05.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-commerce-01",
+    "name": "Commerce User Dump Exposure #1",
+    "description": "Detects exposed Commerce user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/user-dump-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-commerce-02",
+    "name": "Commerce User Dump Exposure #2",
+    "description": "Detects exposed Commerce user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/user-dump-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-commerce-03",
+    "name": "Commerce User Dump Exposure #3",
+    "description": "Detects exposed Commerce user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/commerce/user-dump-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-commerce-04",
+    "name": "Commerce User Dump Exposure #4",
+    "description": "Detects exposed Commerce user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/user-dump-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-commerce-05",
+    "name": "Commerce User Dump Exposure #5",
+    "description": "Detects exposed Commerce user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/user-dump-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-commerce-01",
+    "name": "Commerce Billing Export Exposure #1",
+    "description": "Identifies Commerce billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/billing-export-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-commerce-02",
+    "name": "Commerce Billing Export Exposure #2",
+    "description": "Identifies Commerce billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/billing-export-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-commerce-03",
+    "name": "Commerce Billing Export Exposure #3",
+    "description": "Identifies Commerce billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/commerce/billing-export-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-commerce-04",
+    "name": "Commerce Billing Export Exposure #4",
+    "description": "Identifies Commerce billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/billing-export-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-commerce-05",
+    "name": "Commerce Billing Export Exposure #5",
+    "description": "Identifies Commerce billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/billing-export-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-commerce-01",
+    "name": "Commerce Webhook Registry Leak #1",
+    "description": "Detects leaked Commerce webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/webhooks-registry-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-commerce-02",
+    "name": "Commerce Webhook Registry Leak #2",
+    "description": "Detects leaked Commerce webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/webhooks-registry-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-commerce-03",
+    "name": "Commerce Webhook Registry Leak #3",
+    "description": "Detects leaked Commerce webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/webhooks-registry-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-commerce-04",
+    "name": "Commerce Webhook Registry Leak #4",
+    "description": "Detects leaked Commerce webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/webhooks-registry-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-commerce-05",
+    "name": "Commerce Webhook Registry Leak #5",
+    "description": "Detects leaked Commerce webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/webhooks-registry-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-commerce-01",
+    "name": "Commerce Telemetry Snapshot Exposure #1",
+    "description": "Surfaces exposed Commerce telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/telemetry-snapshot-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-commerce-02",
+    "name": "Commerce Telemetry Snapshot Exposure #2",
+    "description": "Surfaces exposed Commerce telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/telemetry-snapshot-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-commerce-03",
+    "name": "Commerce Telemetry Snapshot Exposure #3",
+    "description": "Surfaces exposed Commerce telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/commerce/telemetry-snapshot-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-commerce-04",
+    "name": "Commerce Telemetry Snapshot Exposure #4",
+    "description": "Surfaces exposed Commerce telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/telemetry-snapshot-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-commerce-05",
+    "name": "Commerce Telemetry Snapshot Exposure #5",
+    "description": "Surfaces exposed Commerce telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/telemetry-snapshot-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-commerce-01",
+    "name": "Commerce Debug Trace Log Leak #1",
+    "description": "Detects leaked Commerce debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/debug-trace-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-commerce-02",
+    "name": "Commerce Debug Trace Log Leak #2",
+    "description": "Detects leaked Commerce debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/debug-trace-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-commerce-03",
+    "name": "Commerce Debug Trace Log Leak #3",
+    "description": "Detects leaked Commerce debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/commerce/debug-trace-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-commerce-04",
+    "name": "Commerce Debug Trace Log Leak #4",
+    "description": "Detects leaked Commerce debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/debug-trace-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-commerce-05",
+    "name": "Commerce Debug Trace Log Leak #5",
+    "description": "Detects leaked Commerce debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/debug-trace-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-commerce-01",
+    "name": "Commerce Database Backup Exposure #1",
+    "description": "Finds exposed Commerce database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/db-backup-01.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-commerce-02",
+    "name": "Commerce Database Backup Exposure #2",
+    "description": "Finds exposed Commerce database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/db-backup-02.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-commerce-03",
+    "name": "Commerce Database Backup Exposure #3",
+    "description": "Finds exposed Commerce database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/db-backup-03.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-commerce-04",
+    "name": "Commerce Database Backup Exposure #4",
+    "description": "Finds exposed Commerce database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/db-backup-04.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-commerce-05",
+    "name": "Commerce Database Backup Exposure #5",
+    "description": "Finds exposed Commerce database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/db-backup-05.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-commerce-01",
+    "name": "Commerce Compliance Report Leak #1",
+    "description": "Detects leaked Commerce compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/compliance-report-01.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-commerce-02",
+    "name": "Commerce Compliance Report Leak #2",
+    "description": "Detects leaked Commerce compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/compliance-report-02.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-commerce-03",
+    "name": "Commerce Compliance Report Leak #3",
+    "description": "Detects leaked Commerce compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/commerce/compliance-report-03.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-commerce-04",
+    "name": "Commerce Compliance Report Leak #4",
+    "description": "Detects leaked Commerce compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/compliance-report-04.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-commerce-05",
+    "name": "Commerce Compliance Report Leak #5",
+    "description": "Detects leaked Commerce compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/compliance-report-05.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-compliance-01",
+    "name": "Compliance Token Cache Dump #1",
+    "description": "Detects exposed Compliance token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/token-cache-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-compliance-02",
+    "name": "Compliance Token Cache Dump #2",
+    "description": "Detects exposed Compliance token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/token-cache-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-compliance-03",
+    "name": "Compliance Token Cache Dump #3",
+    "description": "Detects exposed Compliance token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/token-cache-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-compliance-04",
+    "name": "Compliance Token Cache Dump #4",
+    "description": "Detects exposed Compliance token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/token-cache-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-compliance-05",
+    "name": "Compliance Token Cache Dump #5",
+    "description": "Detects exposed Compliance token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/token-cache-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-compliance-01",
+    "name": "Compliance Session Ledger Leak #1",
+    "description": "Catches leaked Compliance session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/sessions-ledger-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-compliance-02",
+    "name": "Compliance Session Ledger Leak #2",
+    "description": "Catches leaked Compliance session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/sessions-ledger-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-compliance-03",
+    "name": "Compliance Session Ledger Leak #3",
+    "description": "Catches leaked Compliance session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/sessions-ledger-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-compliance-04",
+    "name": "Compliance Session Ledger Leak #4",
+    "description": "Catches leaked Compliance session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/sessions-ledger-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-compliance-05",
+    "name": "Compliance Session Ledger Leak #5",
+    "description": "Catches leaked Compliance session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/sessions-ledger-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-compliance-01",
+    "name": "Compliance Config Export Exposure #1",
+    "description": "Finds world-readable Compliance configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/config-export-01.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-compliance-02",
+    "name": "Compliance Config Export Exposure #2",
+    "description": "Finds world-readable Compliance configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/config-export-02.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-compliance-03",
+    "name": "Compliance Config Export Exposure #3",
+    "description": "Finds world-readable Compliance configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/config-export-03.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-compliance-04",
+    "name": "Compliance Config Export Exposure #4",
+    "description": "Finds world-readable Compliance configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/config-export-04.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-compliance-05",
+    "name": "Compliance Config Export Exposure #5",
+    "description": "Finds world-readable Compliance configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/config-export-05.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-compliance-01",
+    "name": "Compliance User Dump Exposure #1",
+    "description": "Detects exposed Compliance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/user-dump-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-compliance-02",
+    "name": "Compliance User Dump Exposure #2",
+    "description": "Detects exposed Compliance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/user-dump-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-compliance-03",
+    "name": "Compliance User Dump Exposure #3",
+    "description": "Detects exposed Compliance user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/compliance/user-dump-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-compliance-04",
+    "name": "Compliance User Dump Exposure #4",
+    "description": "Detects exposed Compliance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/user-dump-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-compliance-05",
+    "name": "Compliance User Dump Exposure #5",
+    "description": "Detects exposed Compliance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/user-dump-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-compliance-01",
+    "name": "Compliance Billing Export Exposure #1",
+    "description": "Identifies Compliance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/billing-export-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-compliance-02",
+    "name": "Compliance Billing Export Exposure #2",
+    "description": "Identifies Compliance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/billing-export-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-compliance-03",
+    "name": "Compliance Billing Export Exposure #3",
+    "description": "Identifies Compliance billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/compliance/billing-export-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-compliance-04",
+    "name": "Compliance Billing Export Exposure #4",
+    "description": "Identifies Compliance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/billing-export-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-compliance-05",
+    "name": "Compliance Billing Export Exposure #5",
+    "description": "Identifies Compliance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/billing-export-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-compliance-01",
+    "name": "Compliance Webhook Registry Leak #1",
+    "description": "Detects leaked Compliance webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/webhooks-registry-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-compliance-02",
+    "name": "Compliance Webhook Registry Leak #2",
+    "description": "Detects leaked Compliance webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/webhooks-registry-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-compliance-03",
+    "name": "Compliance Webhook Registry Leak #3",
+    "description": "Detects leaked Compliance webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/webhooks-registry-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-compliance-04",
+    "name": "Compliance Webhook Registry Leak #4",
+    "description": "Detects leaked Compliance webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/webhooks-registry-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-compliance-05",
+    "name": "Compliance Webhook Registry Leak #5",
+    "description": "Detects leaked Compliance webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/webhooks-registry-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-compliance-01",
+    "name": "Compliance Telemetry Snapshot Exposure #1",
+    "description": "Surfaces exposed Compliance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/telemetry-snapshot-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-compliance-02",
+    "name": "Compliance Telemetry Snapshot Exposure #2",
+    "description": "Surfaces exposed Compliance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/telemetry-snapshot-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-compliance-03",
+    "name": "Compliance Telemetry Snapshot Exposure #3",
+    "description": "Surfaces exposed Compliance telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/compliance/telemetry-snapshot-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-compliance-04",
+    "name": "Compliance Telemetry Snapshot Exposure #4",
+    "description": "Surfaces exposed Compliance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/telemetry-snapshot-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-compliance-05",
+    "name": "Compliance Telemetry Snapshot Exposure #5",
+    "description": "Surfaces exposed Compliance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/telemetry-snapshot-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-compliance-01",
+    "name": "Compliance Debug Trace Log Leak #1",
+    "description": "Detects leaked Compliance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/debug-trace-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-compliance-02",
+    "name": "Compliance Debug Trace Log Leak #2",
+    "description": "Detects leaked Compliance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/debug-trace-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-compliance-03",
+    "name": "Compliance Debug Trace Log Leak #3",
+    "description": "Detects leaked Compliance debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/compliance/debug-trace-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-compliance-04",
+    "name": "Compliance Debug Trace Log Leak #4",
+    "description": "Detects leaked Compliance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/debug-trace-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-compliance-05",
+    "name": "Compliance Debug Trace Log Leak #5",
+    "description": "Detects leaked Compliance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/debug-trace-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-compliance-01",
+    "name": "Compliance Database Backup Exposure #1",
+    "description": "Finds exposed Compliance database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/db-backup-01.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-compliance-02",
+    "name": "Compliance Database Backup Exposure #2",
+    "description": "Finds exposed Compliance database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/db-backup-02.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-compliance-03",
+    "name": "Compliance Database Backup Exposure #3",
+    "description": "Finds exposed Compliance database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/db-backup-03.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-compliance-04",
+    "name": "Compliance Database Backup Exposure #4",
+    "description": "Finds exposed Compliance database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/db-backup-04.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-compliance-05",
+    "name": "Compliance Database Backup Exposure #5",
+    "description": "Finds exposed Compliance database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/db-backup-05.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-compliance-01",
+    "name": "Compliance Compliance Report Leak #1",
+    "description": "Detects leaked Compliance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/compliance-report-01.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-compliance-02",
+    "name": "Compliance Compliance Report Leak #2",
+    "description": "Detects leaked Compliance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/compliance-report-02.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-compliance-03",
+    "name": "Compliance Compliance Report Leak #3",
+    "description": "Detects leaked Compliance compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/compliance/compliance-report-03.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-compliance-04",
+    "name": "Compliance Compliance Report Leak #4",
+    "description": "Detects leaked Compliance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/compliance-report-04.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-compliance-05",
+    "name": "Compliance Compliance Report Leak #5",
+    "description": "Detects leaked Compliance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/compliance-report-05.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-customer-success-01",
+    "name": "Customer Success Token Cache Dump #1",
+    "description": "Detects exposed Customer Success token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/token-cache-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-customer-success-02",
+    "name": "Customer Success Token Cache Dump #2",
+    "description": "Detects exposed Customer Success token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/token-cache-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-customer-success-03",
+    "name": "Customer Success Token Cache Dump #3",
+    "description": "Detects exposed Customer Success token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/token-cache-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-customer-success-04",
+    "name": "Customer Success Token Cache Dump #4",
+    "description": "Detects exposed Customer Success token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/token-cache-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-customer-success-05",
+    "name": "Customer Success Token Cache Dump #5",
+    "description": "Detects exposed Customer Success token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/token-cache-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-customer-success-01",
+    "name": "Customer Success Session Ledger Leak #1",
+    "description": "Catches leaked Customer Success session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/sessions-ledger-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-customer-success-02",
+    "name": "Customer Success Session Ledger Leak #2",
+    "description": "Catches leaked Customer Success session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/sessions-ledger-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-customer-success-03",
+    "name": "Customer Success Session Ledger Leak #3",
+    "description": "Catches leaked Customer Success session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/sessions-ledger-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-customer-success-04",
+    "name": "Customer Success Session Ledger Leak #4",
+    "description": "Catches leaked Customer Success session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/sessions-ledger-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-customer-success-05",
+    "name": "Customer Success Session Ledger Leak #5",
+    "description": "Catches leaked Customer Success session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/sessions-ledger-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-customer-success-01",
+    "name": "Customer Success Config Export Exposure #1",
+    "description": "Finds world-readable Customer Success configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/config-export-01.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-customer-success-02",
+    "name": "Customer Success Config Export Exposure #2",
+    "description": "Finds world-readable Customer Success configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/config-export-02.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-customer-success-03",
+    "name": "Customer Success Config Export Exposure #3",
+    "description": "Finds world-readable Customer Success configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/config-export-03.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-customer-success-04",
+    "name": "Customer Success Config Export Exposure #4",
+    "description": "Finds world-readable Customer Success configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/config-export-04.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-customer-success-05",
+    "name": "Customer Success Config Export Exposure #5",
+    "description": "Finds world-readable Customer Success configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/config-export-05.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-customer-success-01",
+    "name": "Customer Success User Dump Exposure #1",
+    "description": "Detects exposed Customer Success user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/user-dump-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-customer-success-02",
+    "name": "Customer Success User Dump Exposure #2",
+    "description": "Detects exposed Customer Success user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/user-dump-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-customer-success-03",
+    "name": "Customer Success User Dump Exposure #3",
+    "description": "Detects exposed Customer Success user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/customer-success/user-dump-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-customer-success-04",
+    "name": "Customer Success User Dump Exposure #4",
+    "description": "Detects exposed Customer Success user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/user-dump-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-customer-success-05",
+    "name": "Customer Success User Dump Exposure #5",
+    "description": "Detects exposed Customer Success user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/user-dump-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-customer-success-01",
+    "name": "Customer Success Billing Export Exposure #1",
+    "description": "Identifies Customer Success billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/billing-export-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-customer-success-02",
+    "name": "Customer Success Billing Export Exposure #2",
+    "description": "Identifies Customer Success billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/billing-export-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-customer-success-03",
+    "name": "Customer Success Billing Export Exposure #3",
+    "description": "Identifies Customer Success billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/customer-success/billing-export-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-customer-success-04",
+    "name": "Customer Success Billing Export Exposure #4",
+    "description": "Identifies Customer Success billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/billing-export-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-customer-success-05",
+    "name": "Customer Success Billing Export Exposure #5",
+    "description": "Identifies Customer Success billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/billing-export-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-customer-success-01",
+    "name": "Customer Success Webhook Registry Leak #1",
+    "description": "Detects leaked Customer Success webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/webhooks-registry-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-customer-success-02",
+    "name": "Customer Success Webhook Registry Leak #2",
+    "description": "Detects leaked Customer Success webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/webhooks-registry-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-customer-success-03",
+    "name": "Customer Success Webhook Registry Leak #3",
+    "description": "Detects leaked Customer Success webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/webhooks-registry-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-customer-success-04",
+    "name": "Customer Success Webhook Registry Leak #4",
+    "description": "Detects leaked Customer Success webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/webhooks-registry-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-customer-success-05",
+    "name": "Customer Success Webhook Registry Leak #5",
+    "description": "Detects leaked Customer Success webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/webhooks-registry-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-customer-success-01",
+    "name": "Customer Success Telemetry Snapshot Exposure #1",
+    "description": "Surfaces exposed Customer Success telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/telemetry-snapshot-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-customer-success-02",
+    "name": "Customer Success Telemetry Snapshot Exposure #2",
+    "description": "Surfaces exposed Customer Success telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/telemetry-snapshot-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-customer-success-03",
+    "name": "Customer Success Telemetry Snapshot Exposure #3",
+    "description": "Surfaces exposed Customer Success telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/customer-success/telemetry-snapshot-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-customer-success-04",
+    "name": "Customer Success Telemetry Snapshot Exposure #4",
+    "description": "Surfaces exposed Customer Success telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/telemetry-snapshot-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-customer-success-05",
+    "name": "Customer Success Telemetry Snapshot Exposure #5",
+    "description": "Surfaces exposed Customer Success telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/telemetry-snapshot-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-customer-success-01",
+    "name": "Customer Success Debug Trace Log Leak #1",
+    "description": "Detects leaked Customer Success debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/debug-trace-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-customer-success-02",
+    "name": "Customer Success Debug Trace Log Leak #2",
+    "description": "Detects leaked Customer Success debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/debug-trace-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-customer-success-03",
+    "name": "Customer Success Debug Trace Log Leak #3",
+    "description": "Detects leaked Customer Success debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/customer-success/debug-trace-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-customer-success-04",
+    "name": "Customer Success Debug Trace Log Leak #4",
+    "description": "Detects leaked Customer Success debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/debug-trace-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-customer-success-05",
+    "name": "Customer Success Debug Trace Log Leak #5",
+    "description": "Detects leaked Customer Success debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/debug-trace-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-customer-success-01",
+    "name": "Customer Success Database Backup Exposure #1",
+    "description": "Finds exposed Customer Success database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/db-backup-01.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-customer-success-02",
+    "name": "Customer Success Database Backup Exposure #2",
+    "description": "Finds exposed Customer Success database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/db-backup-02.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-customer-success-03",
+    "name": "Customer Success Database Backup Exposure #3",
+    "description": "Finds exposed Customer Success database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/db-backup-03.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-customer-success-04",
+    "name": "Customer Success Database Backup Exposure #4",
+    "description": "Finds exposed Customer Success database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/db-backup-04.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-customer-success-05",
+    "name": "Customer Success Database Backup Exposure #5",
+    "description": "Finds exposed Customer Success database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/db-backup-05.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-customer-success-01",
+    "name": "Customer Success Compliance Report Leak #1",
+    "description": "Detects leaked Customer Success compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/compliance-report-01.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-customer-success-02",
+    "name": "Customer Success Compliance Report Leak #2",
+    "description": "Detects leaked Customer Success compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/compliance-report-02.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-customer-success-03",
+    "name": "Customer Success Compliance Report Leak #3",
+    "description": "Detects leaked Customer Success compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/customer-success/compliance-report-03.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-customer-success-04",
+    "name": "Customer Success Compliance Report Leak #4",
+    "description": "Detects leaked Customer Success compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/compliance-report-04.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-customer-success-05",
+    "name": "Customer Success Compliance Report Leak #5",
+    "description": "Detects leaked Customer Success compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/compliance-report-05.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-devops-01",
+    "name": "Devops Token Cache Dump #1",
+    "description": "Detects exposed Devops token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/token-cache-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-devops-02",
+    "name": "Devops Token Cache Dump #2",
+    "description": "Detects exposed Devops token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/token-cache-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-devops-03",
+    "name": "Devops Token Cache Dump #3",
+    "description": "Detects exposed Devops token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/token-cache-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-devops-04",
+    "name": "Devops Token Cache Dump #4",
+    "description": "Detects exposed Devops token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/token-cache-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-devops-05",
+    "name": "Devops Token Cache Dump #5",
+    "description": "Detects exposed Devops token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/token-cache-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-devops-01",
+    "name": "Devops Session Ledger Leak #1",
+    "description": "Catches leaked Devops session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/sessions-ledger-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-devops-02",
+    "name": "Devops Session Ledger Leak #2",
+    "description": "Catches leaked Devops session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/sessions-ledger-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-devops-03",
+    "name": "Devops Session Ledger Leak #3",
+    "description": "Catches leaked Devops session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/sessions-ledger-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-devops-04",
+    "name": "Devops Session Ledger Leak #4",
+    "description": "Catches leaked Devops session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/sessions-ledger-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-devops-05",
+    "name": "Devops Session Ledger Leak #5",
+    "description": "Catches leaked Devops session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/sessions-ledger-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-devops-01",
+    "name": "Devops Config Export Exposure #1",
+    "description": "Finds world-readable Devops configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/config-export-01.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-devops-02",
+    "name": "Devops Config Export Exposure #2",
+    "description": "Finds world-readable Devops configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/config-export-02.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-devops-03",
+    "name": "Devops Config Export Exposure #3",
+    "description": "Finds world-readable Devops configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/config-export-03.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-devops-04",
+    "name": "Devops Config Export Exposure #4",
+    "description": "Finds world-readable Devops configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/config-export-04.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-devops-05",
+    "name": "Devops Config Export Exposure #5",
+    "description": "Finds world-readable Devops configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/config-export-05.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-devops-01",
+    "name": "Devops User Dump Exposure #1",
+    "description": "Detects exposed Devops user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/user-dump-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-devops-02",
+    "name": "Devops User Dump Exposure #2",
+    "description": "Detects exposed Devops user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/user-dump-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-devops-03",
+    "name": "Devops User Dump Exposure #3",
+    "description": "Detects exposed Devops user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/devops/user-dump-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-devops-04",
+    "name": "Devops User Dump Exposure #4",
+    "description": "Detects exposed Devops user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/user-dump-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-devops-05",
+    "name": "Devops User Dump Exposure #5",
+    "description": "Detects exposed Devops user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/user-dump-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-devops-01",
+    "name": "Devops Billing Export Exposure #1",
+    "description": "Identifies Devops billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/billing-export-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-devops-02",
+    "name": "Devops Billing Export Exposure #2",
+    "description": "Identifies Devops billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/billing-export-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-devops-03",
+    "name": "Devops Billing Export Exposure #3",
+    "description": "Identifies Devops billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/devops/billing-export-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-devops-04",
+    "name": "Devops Billing Export Exposure #4",
+    "description": "Identifies Devops billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/billing-export-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-devops-05",
+    "name": "Devops Billing Export Exposure #5",
+    "description": "Identifies Devops billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/billing-export-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-devops-01",
+    "name": "Devops Webhook Registry Leak #1",
+    "description": "Detects leaked Devops webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/webhooks-registry-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-devops-02",
+    "name": "Devops Webhook Registry Leak #2",
+    "description": "Detects leaked Devops webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/webhooks-registry-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-devops-03",
+    "name": "Devops Webhook Registry Leak #3",
+    "description": "Detects leaked Devops webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/webhooks-registry-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-devops-04",
+    "name": "Devops Webhook Registry Leak #4",
+    "description": "Detects leaked Devops webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/webhooks-registry-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-devops-05",
+    "name": "Devops Webhook Registry Leak #5",
+    "description": "Detects leaked Devops webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/webhooks-registry-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-devops-01",
+    "name": "Devops Telemetry Snapshot Exposure #1",
+    "description": "Surfaces exposed Devops telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/telemetry-snapshot-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-devops-02",
+    "name": "Devops Telemetry Snapshot Exposure #2",
+    "description": "Surfaces exposed Devops telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/telemetry-snapshot-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-devops-03",
+    "name": "Devops Telemetry Snapshot Exposure #3",
+    "description": "Surfaces exposed Devops telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/devops/telemetry-snapshot-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-devops-04",
+    "name": "Devops Telemetry Snapshot Exposure #4",
+    "description": "Surfaces exposed Devops telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/telemetry-snapshot-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-devops-05",
+    "name": "Devops Telemetry Snapshot Exposure #5",
+    "description": "Surfaces exposed Devops telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/telemetry-snapshot-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-devops-01",
+    "name": "Devops Debug Trace Log Leak #1",
+    "description": "Detects leaked Devops debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/debug-trace-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-devops-02",
+    "name": "Devops Debug Trace Log Leak #2",
+    "description": "Detects leaked Devops debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/debug-trace-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-devops-03",
+    "name": "Devops Debug Trace Log Leak #3",
+    "description": "Detects leaked Devops debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/devops/debug-trace-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-devops-04",
+    "name": "Devops Debug Trace Log Leak #4",
+    "description": "Detects leaked Devops debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/debug-trace-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-devops-05",
+    "name": "Devops Debug Trace Log Leak #5",
+    "description": "Detects leaked Devops debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/debug-trace-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-devops-01",
+    "name": "Devops Database Backup Exposure #1",
+    "description": "Finds exposed Devops database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/db-backup-01.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-devops-02",
+    "name": "Devops Database Backup Exposure #2",
+    "description": "Finds exposed Devops database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/db-backup-02.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-devops-03",
+    "name": "Devops Database Backup Exposure #3",
+    "description": "Finds exposed Devops database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/db-backup-03.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-devops-04",
+    "name": "Devops Database Backup Exposure #4",
+    "description": "Finds exposed Devops database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/db-backup-04.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-devops-05",
+    "name": "Devops Database Backup Exposure #5",
+    "description": "Finds exposed Devops database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/db-backup-05.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-devops-01",
+    "name": "Devops Compliance Report Leak #1",
+    "description": "Detects leaked Devops compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/compliance-report-01.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-devops-02",
+    "name": "Devops Compliance Report Leak #2",
+    "description": "Detects leaked Devops compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/compliance-report-02.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-devops-03",
+    "name": "Devops Compliance Report Leak #3",
+    "description": "Detects leaked Devops compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/devops/compliance-report-03.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-devops-04",
+    "name": "Devops Compliance Report Leak #4",
+    "description": "Detects leaked Devops compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/compliance-report-04.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-devops-05",
+    "name": "Devops Compliance Report Leak #5",
+    "description": "Detects leaked Devops compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/compliance-report-05.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-finance-01",
+    "name": "Finance Token Cache Dump #1",
+    "description": "Detects exposed Finance token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/token-cache-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-finance-02",
+    "name": "Finance Token Cache Dump #2",
+    "description": "Detects exposed Finance token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/token-cache-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-finance-03",
+    "name": "Finance Token Cache Dump #3",
+    "description": "Detects exposed Finance token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/token-cache-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-finance-04",
+    "name": "Finance Token Cache Dump #4",
+    "description": "Detects exposed Finance token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/token-cache-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-finance-05",
+    "name": "Finance Token Cache Dump #5",
+    "description": "Detects exposed Finance token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/token-cache-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-finance-01",
+    "name": "Finance Session Ledger Leak #1",
+    "description": "Catches leaked Finance session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/sessions-ledger-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-finance-02",
+    "name": "Finance Session Ledger Leak #2",
+    "description": "Catches leaked Finance session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/sessions-ledger-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-finance-03",
+    "name": "Finance Session Ledger Leak #3",
+    "description": "Catches leaked Finance session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/sessions-ledger-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-finance-04",
+    "name": "Finance Session Ledger Leak #4",
+    "description": "Catches leaked Finance session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/sessions-ledger-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-finance-05",
+    "name": "Finance Session Ledger Leak #5",
+    "description": "Catches leaked Finance session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/sessions-ledger-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-finance-01",
+    "name": "Finance Config Export Exposure #1",
+    "description": "Finds world-readable Finance configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/config-export-01.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-finance-02",
+    "name": "Finance Config Export Exposure #2",
+    "description": "Finds world-readable Finance configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/config-export-02.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-finance-03",
+    "name": "Finance Config Export Exposure #3",
+    "description": "Finds world-readable Finance configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/config-export-03.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-finance-04",
+    "name": "Finance Config Export Exposure #4",
+    "description": "Finds world-readable Finance configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/config-export-04.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-finance-05",
+    "name": "Finance Config Export Exposure #5",
+    "description": "Finds world-readable Finance configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/config-export-05.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-finance-01",
+    "name": "Finance User Dump Exposure #1",
+    "description": "Detects exposed Finance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/user-dump-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-finance-02",
+    "name": "Finance User Dump Exposure #2",
+    "description": "Detects exposed Finance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/user-dump-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-finance-03",
+    "name": "Finance User Dump Exposure #3",
+    "description": "Detects exposed Finance user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/finance/user-dump-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-finance-04",
+    "name": "Finance User Dump Exposure #4",
+    "description": "Detects exposed Finance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/user-dump-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-finance-05",
+    "name": "Finance User Dump Exposure #5",
+    "description": "Detects exposed Finance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/user-dump-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-finance-01",
+    "name": "Finance Billing Export Exposure #1",
+    "description": "Identifies Finance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/billing-export-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-finance-02",
+    "name": "Finance Billing Export Exposure #2",
+    "description": "Identifies Finance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/billing-export-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-finance-03",
+    "name": "Finance Billing Export Exposure #3",
+    "description": "Identifies Finance billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/finance/billing-export-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-finance-04",
+    "name": "Finance Billing Export Exposure #4",
+    "description": "Identifies Finance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/billing-export-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-finance-05",
+    "name": "Finance Billing Export Exposure #5",
+    "description": "Identifies Finance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/billing-export-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-finance-01",
+    "name": "Finance Webhook Registry Leak #1",
+    "description": "Detects leaked Finance webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/webhooks-registry-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-finance-02",
+    "name": "Finance Webhook Registry Leak #2",
+    "description": "Detects leaked Finance webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/webhooks-registry-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-finance-03",
+    "name": "Finance Webhook Registry Leak #3",
+    "description": "Detects leaked Finance webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/webhooks-registry-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-finance-04",
+    "name": "Finance Webhook Registry Leak #4",
+    "description": "Detects leaked Finance webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/webhooks-registry-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-finance-05",
+    "name": "Finance Webhook Registry Leak #5",
+    "description": "Detects leaked Finance webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/webhooks-registry-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-finance-01",
+    "name": "Finance Telemetry Snapshot Exposure #1",
+    "description": "Surfaces exposed Finance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/telemetry-snapshot-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-finance-02",
+    "name": "Finance Telemetry Snapshot Exposure #2",
+    "description": "Surfaces exposed Finance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/telemetry-snapshot-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-finance-03",
+    "name": "Finance Telemetry Snapshot Exposure #3",
+    "description": "Surfaces exposed Finance telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/finance/telemetry-snapshot-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-finance-04",
+    "name": "Finance Telemetry Snapshot Exposure #4",
+    "description": "Surfaces exposed Finance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/telemetry-snapshot-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-finance-05",
+    "name": "Finance Telemetry Snapshot Exposure #5",
+    "description": "Surfaces exposed Finance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/telemetry-snapshot-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-finance-01",
+    "name": "Finance Debug Trace Log Leak #1",
+    "description": "Detects leaked Finance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/debug-trace-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-finance-02",
+    "name": "Finance Debug Trace Log Leak #2",
+    "description": "Detects leaked Finance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/debug-trace-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-finance-03",
+    "name": "Finance Debug Trace Log Leak #3",
+    "description": "Detects leaked Finance debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/finance/debug-trace-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-finance-04",
+    "name": "Finance Debug Trace Log Leak #4",
+    "description": "Detects leaked Finance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/debug-trace-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-finance-05",
+    "name": "Finance Debug Trace Log Leak #5",
+    "description": "Detects leaked Finance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/debug-trace-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-finance-01",
+    "name": "Finance Database Backup Exposure #1",
+    "description": "Finds exposed Finance database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/db-backup-01.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-finance-02",
+    "name": "Finance Database Backup Exposure #2",
+    "description": "Finds exposed Finance database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/db-backup-02.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-finance-03",
+    "name": "Finance Database Backup Exposure #3",
+    "description": "Finds exposed Finance database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/db-backup-03.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-finance-04",
+    "name": "Finance Database Backup Exposure #4",
+    "description": "Finds exposed Finance database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/db-backup-04.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-finance-05",
+    "name": "Finance Database Backup Exposure #5",
+    "description": "Finds exposed Finance database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/db-backup-05.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-finance-01",
+    "name": "Finance Compliance Report Leak #1",
+    "description": "Detects leaked Finance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/compliance-report-01.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-finance-02",
+    "name": "Finance Compliance Report Leak #2",
+    "description": "Detects leaked Finance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/compliance-report-02.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-finance-03",
+    "name": "Finance Compliance Report Leak #3",
+    "description": "Detects leaked Finance compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/finance/compliance-report-03.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-finance-04",
+    "name": "Finance Compliance Report Leak #4",
+    "description": "Detects leaked Finance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/compliance-report-04.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-finance-05",
+    "name": "Finance Compliance Report Leak #5",
+    "description": "Detects leaked Finance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/compliance-report-05.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-governance-01",
+    "name": "Governance Token Cache Dump #1",
+    "description": "Detects exposed Governance token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/token-cache-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-governance-02",
+    "name": "Governance Token Cache Dump #2",
+    "description": "Detects exposed Governance token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/token-cache-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-governance-03",
+    "name": "Governance Token Cache Dump #3",
+    "description": "Detects exposed Governance token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/token-cache-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-governance-04",
+    "name": "Governance Token Cache Dump #4",
+    "description": "Detects exposed Governance token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/token-cache-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-governance-05",
+    "name": "Governance Token Cache Dump #5",
+    "description": "Detects exposed Governance token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/token-cache-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-governance-01",
+    "name": "Governance Session Ledger Leak #1",
+    "description": "Catches leaked Governance session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/sessions-ledger-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-governance-02",
+    "name": "Governance Session Ledger Leak #2",
+    "description": "Catches leaked Governance session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/sessions-ledger-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-governance-03",
+    "name": "Governance Session Ledger Leak #3",
+    "description": "Catches leaked Governance session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/sessions-ledger-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-governance-04",
+    "name": "Governance Session Ledger Leak #4",
+    "description": "Catches leaked Governance session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/sessions-ledger-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-governance-05",
+    "name": "Governance Session Ledger Leak #5",
+    "description": "Catches leaked Governance session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/sessions-ledger-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-governance-01",
+    "name": "Governance Config Export Exposure #1",
+    "description": "Finds world-readable Governance configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/config-export-01.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-governance-02",
+    "name": "Governance Config Export Exposure #2",
+    "description": "Finds world-readable Governance configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/config-export-02.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-governance-03",
+    "name": "Governance Config Export Exposure #3",
+    "description": "Finds world-readable Governance configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/config-export-03.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-governance-04",
+    "name": "Governance Config Export Exposure #4",
+    "description": "Finds world-readable Governance configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/config-export-04.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-governance-05",
+    "name": "Governance Config Export Exposure #5",
+    "description": "Finds world-readable Governance configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/config-export-05.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-governance-01",
+    "name": "Governance User Dump Exposure #1",
+    "description": "Detects exposed Governance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/user-dump-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-governance-02",
+    "name": "Governance User Dump Exposure #2",
+    "description": "Detects exposed Governance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/user-dump-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-governance-03",
+    "name": "Governance User Dump Exposure #3",
+    "description": "Detects exposed Governance user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/governance/user-dump-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-governance-04",
+    "name": "Governance User Dump Exposure #4",
+    "description": "Detects exposed Governance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/user-dump-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-governance-05",
+    "name": "Governance User Dump Exposure #5",
+    "description": "Detects exposed Governance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/user-dump-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-governance-01",
+    "name": "Governance Billing Export Exposure #1",
+    "description": "Identifies Governance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/billing-export-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-governance-02",
+    "name": "Governance Billing Export Exposure #2",
+    "description": "Identifies Governance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/billing-export-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-governance-03",
+    "name": "Governance Billing Export Exposure #3",
+    "description": "Identifies Governance billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/governance/billing-export-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-governance-04",
+    "name": "Governance Billing Export Exposure #4",
+    "description": "Identifies Governance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/billing-export-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-governance-05",
+    "name": "Governance Billing Export Exposure #5",
+    "description": "Identifies Governance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/billing-export-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-governance-01",
+    "name": "Governance Webhook Registry Leak #1",
+    "description": "Detects leaked Governance webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/webhooks-registry-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-governance-02",
+    "name": "Governance Webhook Registry Leak #2",
+    "description": "Detects leaked Governance webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/webhooks-registry-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-governance-03",
+    "name": "Governance Webhook Registry Leak #3",
+    "description": "Detects leaked Governance webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/webhooks-registry-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-governance-04",
+    "name": "Governance Webhook Registry Leak #4",
+    "description": "Detects leaked Governance webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/webhooks-registry-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-governance-05",
+    "name": "Governance Webhook Registry Leak #5",
+    "description": "Detects leaked Governance webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/webhooks-registry-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-governance-01",
+    "name": "Governance Telemetry Snapshot Exposure #1",
+    "description": "Surfaces exposed Governance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/telemetry-snapshot-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-governance-02",
+    "name": "Governance Telemetry Snapshot Exposure #2",
+    "description": "Surfaces exposed Governance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/telemetry-snapshot-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-governance-03",
+    "name": "Governance Telemetry Snapshot Exposure #3",
+    "description": "Surfaces exposed Governance telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/governance/telemetry-snapshot-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-governance-04",
+    "name": "Governance Telemetry Snapshot Exposure #4",
+    "description": "Surfaces exposed Governance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/telemetry-snapshot-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-governance-05",
+    "name": "Governance Telemetry Snapshot Exposure #5",
+    "description": "Surfaces exposed Governance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/telemetry-snapshot-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-governance-01",
+    "name": "Governance Debug Trace Log Leak #1",
+    "description": "Detects leaked Governance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/debug-trace-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-governance-02",
+    "name": "Governance Debug Trace Log Leak #2",
+    "description": "Detects leaked Governance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/debug-trace-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-governance-03",
+    "name": "Governance Debug Trace Log Leak #3",
+    "description": "Detects leaked Governance debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/governance/debug-trace-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-governance-04",
+    "name": "Governance Debug Trace Log Leak #4",
+    "description": "Detects leaked Governance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/debug-trace-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-governance-05",
+    "name": "Governance Debug Trace Log Leak #5",
+    "description": "Detects leaked Governance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/debug-trace-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-governance-01",
+    "name": "Governance Database Backup Exposure #1",
+    "description": "Finds exposed Governance database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/db-backup-01.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-governance-02",
+    "name": "Governance Database Backup Exposure #2",
+    "description": "Finds exposed Governance database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/db-backup-02.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-governance-03",
+    "name": "Governance Database Backup Exposure #3",
+    "description": "Finds exposed Governance database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/db-backup-03.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-governance-04",
+    "name": "Governance Database Backup Exposure #4",
+    "description": "Finds exposed Governance database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/db-backup-04.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-governance-05",
+    "name": "Governance Database Backup Exposure #5",
+    "description": "Finds exposed Governance database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/db-backup-05.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-governance-01",
+    "name": "Governance Compliance Report Leak #1",
+    "description": "Detects leaked Governance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/compliance-report-01.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-governance-02",
+    "name": "Governance Compliance Report Leak #2",
+    "description": "Detects leaked Governance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/compliance-report-02.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-governance-03",
+    "name": "Governance Compliance Report Leak #3",
+    "description": "Detects leaked Governance compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/governance/compliance-report-03.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-governance-04",
+    "name": "Governance Compliance Report Leak #4",
+    "description": "Detects leaked Governance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/compliance-report-04.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-governance-05",
+    "name": "Governance Compliance Report Leak #5",
+    "description": "Detects leaked Governance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/compliance-report-05.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-identity-01",
+    "name": "Identity Token Cache Dump #1",
+    "description": "Detects exposed Identity token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/token-cache-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-identity-02",
+    "name": "Identity Token Cache Dump #2",
+    "description": "Detects exposed Identity token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/token-cache-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-identity-03",
+    "name": "Identity Token Cache Dump #3",
+    "description": "Detects exposed Identity token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/token-cache-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-identity-04",
+    "name": "Identity Token Cache Dump #4",
+    "description": "Detects exposed Identity token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/token-cache-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-identity-05",
+    "name": "Identity Token Cache Dump #5",
+    "description": "Detects exposed Identity token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/token-cache-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-identity-01",
+    "name": "Identity Session Ledger Leak #1",
+    "description": "Catches leaked Identity session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/sessions-ledger-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-identity-02",
+    "name": "Identity Session Ledger Leak #2",
+    "description": "Catches leaked Identity session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/sessions-ledger-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-identity-03",
+    "name": "Identity Session Ledger Leak #3",
+    "description": "Catches leaked Identity session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/sessions-ledger-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-identity-04",
+    "name": "Identity Session Ledger Leak #4",
+    "description": "Catches leaked Identity session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/sessions-ledger-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-identity-05",
+    "name": "Identity Session Ledger Leak #5",
+    "description": "Catches leaked Identity session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/sessions-ledger-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-identity-01",
+    "name": "Identity Config Export Exposure #1",
+    "description": "Finds world-readable Identity configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/config-export-01.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-identity-02",
+    "name": "Identity Config Export Exposure #2",
+    "description": "Finds world-readable Identity configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/config-export-02.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-identity-03",
+    "name": "Identity Config Export Exposure #3",
+    "description": "Finds world-readable Identity configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/config-export-03.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-identity-04",
+    "name": "Identity Config Export Exposure #4",
+    "description": "Finds world-readable Identity configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/config-export-04.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-identity-05",
+    "name": "Identity Config Export Exposure #5",
+    "description": "Finds world-readable Identity configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/config-export-05.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-identity-01",
+    "name": "Identity User Dump Exposure #1",
+    "description": "Detects exposed Identity user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/user-dump-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-identity-02",
+    "name": "Identity User Dump Exposure #2",
+    "description": "Detects exposed Identity user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/user-dump-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-identity-03",
+    "name": "Identity User Dump Exposure #3",
+    "description": "Detects exposed Identity user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/identity/user-dump-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-identity-04",
+    "name": "Identity User Dump Exposure #4",
+    "description": "Detects exposed Identity user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/user-dump-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-identity-05",
+    "name": "Identity User Dump Exposure #5",
+    "description": "Detects exposed Identity user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/user-dump-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-identity-01",
+    "name": "Identity Billing Export Exposure #1",
+    "description": "Identifies Identity billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/billing-export-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-identity-02",
+    "name": "Identity Billing Export Exposure #2",
+    "description": "Identifies Identity billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/billing-export-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-identity-03",
+    "name": "Identity Billing Export Exposure #3",
+    "description": "Identifies Identity billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/identity/billing-export-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-identity-04",
+    "name": "Identity Billing Export Exposure #4",
+    "description": "Identifies Identity billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/billing-export-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-identity-05",
+    "name": "Identity Billing Export Exposure #5",
+    "description": "Identifies Identity billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/billing-export-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-identity-01",
+    "name": "Identity Webhook Registry Leak #1",
+    "description": "Detects leaked Identity webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/webhooks-registry-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-identity-02",
+    "name": "Identity Webhook Registry Leak #2",
+    "description": "Detects leaked Identity webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/webhooks-registry-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-identity-03",
+    "name": "Identity Webhook Registry Leak #3",
+    "description": "Detects leaked Identity webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/webhooks-registry-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-identity-04",
+    "name": "Identity Webhook Registry Leak #4",
+    "description": "Detects leaked Identity webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/webhooks-registry-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-identity-05",
+    "name": "Identity Webhook Registry Leak #5",
+    "description": "Detects leaked Identity webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/webhooks-registry-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-identity-01",
+    "name": "Identity Telemetry Snapshot Exposure #1",
+    "description": "Surfaces exposed Identity telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/telemetry-snapshot-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-identity-02",
+    "name": "Identity Telemetry Snapshot Exposure #2",
+    "description": "Surfaces exposed Identity telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/telemetry-snapshot-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-identity-03",
+    "name": "Identity Telemetry Snapshot Exposure #3",
+    "description": "Surfaces exposed Identity telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/identity/telemetry-snapshot-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-identity-04",
+    "name": "Identity Telemetry Snapshot Exposure #4",
+    "description": "Surfaces exposed Identity telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/telemetry-snapshot-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-identity-05",
+    "name": "Identity Telemetry Snapshot Exposure #5",
+    "description": "Surfaces exposed Identity telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/telemetry-snapshot-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-identity-01",
+    "name": "Identity Debug Trace Log Leak #1",
+    "description": "Detects leaked Identity debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/debug-trace-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-identity-02",
+    "name": "Identity Debug Trace Log Leak #2",
+    "description": "Detects leaked Identity debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/debug-trace-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-identity-03",
+    "name": "Identity Debug Trace Log Leak #3",
+    "description": "Detects leaked Identity debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/identity/debug-trace-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-identity-04",
+    "name": "Identity Debug Trace Log Leak #4",
+    "description": "Detects leaked Identity debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/debug-trace-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-identity-05",
+    "name": "Identity Debug Trace Log Leak #5",
+    "description": "Detects leaked Identity debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/debug-trace-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-identity-01",
+    "name": "Identity Database Backup Exposure #1",
+    "description": "Finds exposed Identity database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/db-backup-01.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-identity-02",
+    "name": "Identity Database Backup Exposure #2",
+    "description": "Finds exposed Identity database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/db-backup-02.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-identity-03",
+    "name": "Identity Database Backup Exposure #3",
+    "description": "Finds exposed Identity database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/db-backup-03.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-identity-04",
+    "name": "Identity Database Backup Exposure #4",
+    "description": "Finds exposed Identity database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/db-backup-04.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-identity-05",
+    "name": "Identity Database Backup Exposure #5",
+    "description": "Finds exposed Identity database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/db-backup-05.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-identity-01",
+    "name": "Identity Compliance Report Leak #1",
+    "description": "Detects leaked Identity compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/compliance-report-01.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-identity-02",
+    "name": "Identity Compliance Report Leak #2",
+    "description": "Detects leaked Identity compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/compliance-report-02.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-identity-03",
+    "name": "Identity Compliance Report Leak #3",
+    "description": "Detects leaked Identity compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/identity/compliance-report-03.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-identity-04",
+    "name": "Identity Compliance Report Leak #4",
+    "description": "Detects leaked Identity compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/compliance-report-04.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-identity-05",
+    "name": "Identity Compliance Report Leak #5",
+    "description": "Detects leaked Identity compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/compliance-report-05.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-infrastructure-01",
+    "name": "Infrastructure Token Cache Dump #1",
+    "description": "Detects exposed Infrastructure token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/token-cache-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-infrastructure-02",
+    "name": "Infrastructure Token Cache Dump #2",
+    "description": "Detects exposed Infrastructure token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/token-cache-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-infrastructure-03",
+    "name": "Infrastructure Token Cache Dump #3",
+    "description": "Detects exposed Infrastructure token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/token-cache-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-infrastructure-04",
+    "name": "Infrastructure Token Cache Dump #4",
+    "description": "Detects exposed Infrastructure token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/token-cache-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-infrastructure-05",
+    "name": "Infrastructure Token Cache Dump #5",
+    "description": "Detects exposed Infrastructure token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/token-cache-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-infrastructure-01",
+    "name": "Infrastructure Session Ledger Leak #1",
+    "description": "Catches leaked Infrastructure session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/sessions-ledger-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-infrastructure-02",
+    "name": "Infrastructure Session Ledger Leak #2",
+    "description": "Catches leaked Infrastructure session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/sessions-ledger-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-infrastructure-03",
+    "name": "Infrastructure Session Ledger Leak #3",
+    "description": "Catches leaked Infrastructure session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/sessions-ledger-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-infrastructure-04",
+    "name": "Infrastructure Session Ledger Leak #4",
+    "description": "Catches leaked Infrastructure session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/sessions-ledger-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-infrastructure-05",
+    "name": "Infrastructure Session Ledger Leak #5",
+    "description": "Catches leaked Infrastructure session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/sessions-ledger-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-infrastructure-01",
+    "name": "Infrastructure Config Export Exposure #1",
+    "description": "Finds world-readable Infrastructure configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/config-export-01.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-infrastructure-02",
+    "name": "Infrastructure Config Export Exposure #2",
+    "description": "Finds world-readable Infrastructure configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/config-export-02.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-infrastructure-03",
+    "name": "Infrastructure Config Export Exposure #3",
+    "description": "Finds world-readable Infrastructure configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/config-export-03.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-infrastructure-04",
+    "name": "Infrastructure Config Export Exposure #4",
+    "description": "Finds world-readable Infrastructure configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/config-export-04.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-infrastructure-05",
+    "name": "Infrastructure Config Export Exposure #5",
+    "description": "Finds world-readable Infrastructure configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/config-export-05.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-infrastructure-01",
+    "name": "Infrastructure User Dump Exposure #1",
+    "description": "Detects exposed Infrastructure user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/user-dump-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-infrastructure-02",
+    "name": "Infrastructure User Dump Exposure #2",
+    "description": "Detects exposed Infrastructure user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/user-dump-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-infrastructure-03",
+    "name": "Infrastructure User Dump Exposure #3",
+    "description": "Detects exposed Infrastructure user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/infrastructure/user-dump-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-infrastructure-04",
+    "name": "Infrastructure User Dump Exposure #4",
+    "description": "Detects exposed Infrastructure user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/user-dump-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-infrastructure-05",
+    "name": "Infrastructure User Dump Exposure #5",
+    "description": "Detects exposed Infrastructure user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/user-dump-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-infrastructure-01",
+    "name": "Infrastructure Billing Export Exposure #1",
+    "description": "Identifies Infrastructure billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/billing-export-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-infrastructure-02",
+    "name": "Infrastructure Billing Export Exposure #2",
+    "description": "Identifies Infrastructure billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/billing-export-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-infrastructure-03",
+    "name": "Infrastructure Billing Export Exposure #3",
+    "description": "Identifies Infrastructure billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/infrastructure/billing-export-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-infrastructure-04",
+    "name": "Infrastructure Billing Export Exposure #4",
+    "description": "Identifies Infrastructure billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/billing-export-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-infrastructure-05",
+    "name": "Infrastructure Billing Export Exposure #5",
+    "description": "Identifies Infrastructure billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/billing-export-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-infrastructure-01",
+    "name": "Infrastructure Webhook Registry Leak #1",
+    "description": "Detects leaked Infrastructure webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/webhooks-registry-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-infrastructure-02",
+    "name": "Infrastructure Webhook Registry Leak #2",
+    "description": "Detects leaked Infrastructure webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/webhooks-registry-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-infrastructure-03",
+    "name": "Infrastructure Webhook Registry Leak #3",
+    "description": "Detects leaked Infrastructure webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/webhooks-registry-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-infrastructure-04",
+    "name": "Infrastructure Webhook Registry Leak #4",
+    "description": "Detects leaked Infrastructure webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/webhooks-registry-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-infrastructure-05",
+    "name": "Infrastructure Webhook Registry Leak #5",
+    "description": "Detects leaked Infrastructure webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/webhooks-registry-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-infrastructure-01",
+    "name": "Infrastructure Telemetry Snapshot Exposure #1",
+    "description": "Surfaces exposed Infrastructure telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/telemetry-snapshot-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-infrastructure-02",
+    "name": "Infrastructure Telemetry Snapshot Exposure #2",
+    "description": "Surfaces exposed Infrastructure telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/telemetry-snapshot-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-infrastructure-03",
+    "name": "Infrastructure Telemetry Snapshot Exposure #3",
+    "description": "Surfaces exposed Infrastructure telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/infrastructure/telemetry-snapshot-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-infrastructure-04",
+    "name": "Infrastructure Telemetry Snapshot Exposure #4",
+    "description": "Surfaces exposed Infrastructure telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/telemetry-snapshot-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-infrastructure-05",
+    "name": "Infrastructure Telemetry Snapshot Exposure #5",
+    "description": "Surfaces exposed Infrastructure telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/telemetry-snapshot-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-infrastructure-01",
+    "name": "Infrastructure Debug Trace Log Leak #1",
+    "description": "Detects leaked Infrastructure debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/debug-trace-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-infrastructure-02",
+    "name": "Infrastructure Debug Trace Log Leak #2",
+    "description": "Detects leaked Infrastructure debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/debug-trace-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-infrastructure-03",
+    "name": "Infrastructure Debug Trace Log Leak #3",
+    "description": "Detects leaked Infrastructure debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/infrastructure/debug-trace-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-infrastructure-04",
+    "name": "Infrastructure Debug Trace Log Leak #4",
+    "description": "Detects leaked Infrastructure debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/debug-trace-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-infrastructure-05",
+    "name": "Infrastructure Debug Trace Log Leak #5",
+    "description": "Detects leaked Infrastructure debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/debug-trace-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-infrastructure-01",
+    "name": "Infrastructure Database Backup Exposure #1",
+    "description": "Finds exposed Infrastructure database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/db-backup-01.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-infrastructure-02",
+    "name": "Infrastructure Database Backup Exposure #2",
+    "description": "Finds exposed Infrastructure database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/db-backup-02.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-infrastructure-03",
+    "name": "Infrastructure Database Backup Exposure #3",
+    "description": "Finds exposed Infrastructure database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/db-backup-03.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-infrastructure-04",
+    "name": "Infrastructure Database Backup Exposure #4",
+    "description": "Finds exposed Infrastructure database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/db-backup-04.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-infrastructure-05",
+    "name": "Infrastructure Database Backup Exposure #5",
+    "description": "Finds exposed Infrastructure database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/db-backup-05.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-infrastructure-01",
+    "name": "Infrastructure Compliance Report Leak #1",
+    "description": "Detects leaked Infrastructure compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/compliance-report-01.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-infrastructure-02",
+    "name": "Infrastructure Compliance Report Leak #2",
+    "description": "Detects leaked Infrastructure compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/compliance-report-02.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-infrastructure-03",
+    "name": "Infrastructure Compliance Report Leak #3",
+    "description": "Detects leaked Infrastructure compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/infrastructure/compliance-report-03.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-infrastructure-04",
+    "name": "Infrastructure Compliance Report Leak #4",
+    "description": "Detects leaked Infrastructure compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/compliance-report-04.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-infrastructure-05",
+    "name": "Infrastructure Compliance Report Leak #5",
+    "description": "Detects leaked Infrastructure compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/compliance-report-05.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-logistics-01",
+    "name": "Logistics Token Cache Dump #1",
+    "description": "Detects exposed Logistics token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/token-cache-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-logistics-02",
+    "name": "Logistics Token Cache Dump #2",
+    "description": "Detects exposed Logistics token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/token-cache-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-logistics-03",
+    "name": "Logistics Token Cache Dump #3",
+    "description": "Detects exposed Logistics token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/token-cache-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-logistics-04",
+    "name": "Logistics Token Cache Dump #4",
+    "description": "Detects exposed Logistics token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/token-cache-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-logistics-05",
+    "name": "Logistics Token Cache Dump #5",
+    "description": "Detects exposed Logistics token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/token-cache-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-logistics-01",
+    "name": "Logistics Session Ledger Leak #1",
+    "description": "Catches leaked Logistics session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/sessions-ledger-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-logistics-02",
+    "name": "Logistics Session Ledger Leak #2",
+    "description": "Catches leaked Logistics session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/sessions-ledger-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-logistics-03",
+    "name": "Logistics Session Ledger Leak #3",
+    "description": "Catches leaked Logistics session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/sessions-ledger-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-logistics-04",
+    "name": "Logistics Session Ledger Leak #4",
+    "description": "Catches leaked Logistics session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/sessions-ledger-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-logistics-05",
+    "name": "Logistics Session Ledger Leak #5",
+    "description": "Catches leaked Logistics session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/sessions-ledger-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-logistics-01",
+    "name": "Logistics Config Export Exposure #1",
+    "description": "Finds world-readable Logistics configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/config-export-01.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-logistics-02",
+    "name": "Logistics Config Export Exposure #2",
+    "description": "Finds world-readable Logistics configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/config-export-02.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-logistics-03",
+    "name": "Logistics Config Export Exposure #3",
+    "description": "Finds world-readable Logistics configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/config-export-03.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-logistics-04",
+    "name": "Logistics Config Export Exposure #4",
+    "description": "Finds world-readable Logistics configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/config-export-04.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-logistics-05",
+    "name": "Logistics Config Export Exposure #5",
+    "description": "Finds world-readable Logistics configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/config-export-05.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-logistics-01",
+    "name": "Logistics User Dump Exposure #1",
+    "description": "Detects exposed Logistics user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/user-dump-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-logistics-02",
+    "name": "Logistics User Dump Exposure #2",
+    "description": "Detects exposed Logistics user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/user-dump-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-logistics-03",
+    "name": "Logistics User Dump Exposure #3",
+    "description": "Detects exposed Logistics user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/logistics/user-dump-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-logistics-04",
+    "name": "Logistics User Dump Exposure #4",
+    "description": "Detects exposed Logistics user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/user-dump-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-logistics-05",
+    "name": "Logistics User Dump Exposure #5",
+    "description": "Detects exposed Logistics user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/user-dump-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-logistics-01",
+    "name": "Logistics Billing Export Exposure #1",
+    "description": "Identifies Logistics billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/billing-export-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-logistics-02",
+    "name": "Logistics Billing Export Exposure #2",
+    "description": "Identifies Logistics billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/billing-export-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-logistics-03",
+    "name": "Logistics Billing Export Exposure #3",
+    "description": "Identifies Logistics billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/logistics/billing-export-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-logistics-04",
+    "name": "Logistics Billing Export Exposure #4",
+    "description": "Identifies Logistics billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/billing-export-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-logistics-05",
+    "name": "Logistics Billing Export Exposure #5",
+    "description": "Identifies Logistics billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/billing-export-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-logistics-01",
+    "name": "Logistics Webhook Registry Leak #1",
+    "description": "Detects leaked Logistics webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/webhooks-registry-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-logistics-02",
+    "name": "Logistics Webhook Registry Leak #2",
+    "description": "Detects leaked Logistics webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/webhooks-registry-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-logistics-03",
+    "name": "Logistics Webhook Registry Leak #3",
+    "description": "Detects leaked Logistics webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/webhooks-registry-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-logistics-04",
+    "name": "Logistics Webhook Registry Leak #4",
+    "description": "Detects leaked Logistics webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/webhooks-registry-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-logistics-05",
+    "name": "Logistics Webhook Registry Leak #5",
+    "description": "Detects leaked Logistics webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/webhooks-registry-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-logistics-01",
+    "name": "Logistics Telemetry Snapshot Exposure #1",
+    "description": "Surfaces exposed Logistics telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/telemetry-snapshot-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-logistics-02",
+    "name": "Logistics Telemetry Snapshot Exposure #2",
+    "description": "Surfaces exposed Logistics telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/telemetry-snapshot-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-logistics-03",
+    "name": "Logistics Telemetry Snapshot Exposure #3",
+    "description": "Surfaces exposed Logistics telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/logistics/telemetry-snapshot-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-logistics-04",
+    "name": "Logistics Telemetry Snapshot Exposure #4",
+    "description": "Surfaces exposed Logistics telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/telemetry-snapshot-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-logistics-05",
+    "name": "Logistics Telemetry Snapshot Exposure #5",
+    "description": "Surfaces exposed Logistics telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/telemetry-snapshot-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-logistics-01",
+    "name": "Logistics Debug Trace Log Leak #1",
+    "description": "Detects leaked Logistics debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/debug-trace-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-logistics-02",
+    "name": "Logistics Debug Trace Log Leak #2",
+    "description": "Detects leaked Logistics debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/debug-trace-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-logistics-03",
+    "name": "Logistics Debug Trace Log Leak #3",
+    "description": "Detects leaked Logistics debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/logistics/debug-trace-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-logistics-04",
+    "name": "Logistics Debug Trace Log Leak #4",
+    "description": "Detects leaked Logistics debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/debug-trace-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-logistics-05",
+    "name": "Logistics Debug Trace Log Leak #5",
+    "description": "Detects leaked Logistics debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/debug-trace-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-logistics-01",
+    "name": "Logistics Database Backup Exposure #1",
+    "description": "Finds exposed Logistics database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/db-backup-01.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-logistics-02",
+    "name": "Logistics Database Backup Exposure #2",
+    "description": "Finds exposed Logistics database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/db-backup-02.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-logistics-03",
+    "name": "Logistics Database Backup Exposure #3",
+    "description": "Finds exposed Logistics database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/db-backup-03.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-logistics-04",
+    "name": "Logistics Database Backup Exposure #4",
+    "description": "Finds exposed Logistics database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/db-backup-04.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-logistics-05",
+    "name": "Logistics Database Backup Exposure #5",
+    "description": "Finds exposed Logistics database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/db-backup-05.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-logistics-01",
+    "name": "Logistics Compliance Report Leak #1",
+    "description": "Detects leaked Logistics compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/compliance-report-01.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-logistics-02",
+    "name": "Logistics Compliance Report Leak #2",
+    "description": "Detects leaked Logistics compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/compliance-report-02.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-logistics-03",
+    "name": "Logistics Compliance Report Leak #3",
+    "description": "Detects leaked Logistics compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/logistics/compliance-report-03.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-logistics-04",
+    "name": "Logistics Compliance Report Leak #4",
+    "description": "Detects leaked Logistics compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/compliance-report-04.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-logistics-05",
+    "name": "Logistics Compliance Report Leak #5",
+    "description": "Detects leaked Logistics compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/compliance-report-05.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-marketing-01",
+    "name": "Marketing Token Cache Dump #1",
+    "description": "Detects exposed Marketing token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/token-cache-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-marketing-02",
+    "name": "Marketing Token Cache Dump #2",
+    "description": "Detects exposed Marketing token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/token-cache-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-marketing-03",
+    "name": "Marketing Token Cache Dump #3",
+    "description": "Detects exposed Marketing token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/token-cache-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-marketing-04",
+    "name": "Marketing Token Cache Dump #4",
+    "description": "Detects exposed Marketing token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/token-cache-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-marketing-05",
+    "name": "Marketing Token Cache Dump #5",
+    "description": "Detects exposed Marketing token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/token-cache-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-marketing-01",
+    "name": "Marketing Session Ledger Leak #1",
+    "description": "Catches leaked Marketing session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/sessions-ledger-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-marketing-02",
+    "name": "Marketing Session Ledger Leak #2",
+    "description": "Catches leaked Marketing session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/sessions-ledger-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-marketing-03",
+    "name": "Marketing Session Ledger Leak #3",
+    "description": "Catches leaked Marketing session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/sessions-ledger-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-marketing-04",
+    "name": "Marketing Session Ledger Leak #4",
+    "description": "Catches leaked Marketing session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/sessions-ledger-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-marketing-05",
+    "name": "Marketing Session Ledger Leak #5",
+    "description": "Catches leaked Marketing session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/sessions-ledger-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-marketing-01",
+    "name": "Marketing Config Export Exposure #1",
+    "description": "Finds world-readable Marketing configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/config-export-01.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-marketing-02",
+    "name": "Marketing Config Export Exposure #2",
+    "description": "Finds world-readable Marketing configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/config-export-02.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-marketing-03",
+    "name": "Marketing Config Export Exposure #3",
+    "description": "Finds world-readable Marketing configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/config-export-03.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-marketing-04",
+    "name": "Marketing Config Export Exposure #4",
+    "description": "Finds world-readable Marketing configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/config-export-04.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-marketing-05",
+    "name": "Marketing Config Export Exposure #5",
+    "description": "Finds world-readable Marketing configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/config-export-05.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-marketing-01",
+    "name": "Marketing User Dump Exposure #1",
+    "description": "Detects exposed Marketing user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/user-dump-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-marketing-02",
+    "name": "Marketing User Dump Exposure #2",
+    "description": "Detects exposed Marketing user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/user-dump-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-marketing-03",
+    "name": "Marketing User Dump Exposure #3",
+    "description": "Detects exposed Marketing user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/marketing/user-dump-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-marketing-04",
+    "name": "Marketing User Dump Exposure #4",
+    "description": "Detects exposed Marketing user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/user-dump-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-marketing-05",
+    "name": "Marketing User Dump Exposure #5",
+    "description": "Detects exposed Marketing user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/user-dump-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-marketing-01",
+    "name": "Marketing Billing Export Exposure #1",
+    "description": "Identifies Marketing billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/billing-export-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-marketing-02",
+    "name": "Marketing Billing Export Exposure #2",
+    "description": "Identifies Marketing billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/billing-export-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-marketing-03",
+    "name": "Marketing Billing Export Exposure #3",
+    "description": "Identifies Marketing billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/marketing/billing-export-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-marketing-04",
+    "name": "Marketing Billing Export Exposure #4",
+    "description": "Identifies Marketing billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/billing-export-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-marketing-05",
+    "name": "Marketing Billing Export Exposure #5",
+    "description": "Identifies Marketing billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/billing-export-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-marketing-01",
+    "name": "Marketing Webhook Registry Leak #1",
+    "description": "Detects leaked Marketing webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/webhooks-registry-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-marketing-02",
+    "name": "Marketing Webhook Registry Leak #2",
+    "description": "Detects leaked Marketing webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/webhooks-registry-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-marketing-03",
+    "name": "Marketing Webhook Registry Leak #3",
+    "description": "Detects leaked Marketing webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/webhooks-registry-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-marketing-04",
+    "name": "Marketing Webhook Registry Leak #4",
+    "description": "Detects leaked Marketing webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/webhooks-registry-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-marketing-05",
+    "name": "Marketing Webhook Registry Leak #5",
+    "description": "Detects leaked Marketing webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/webhooks-registry-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-marketing-01",
+    "name": "Marketing Telemetry Snapshot Exposure #1",
+    "description": "Surfaces exposed Marketing telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/telemetry-snapshot-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-marketing-02",
+    "name": "Marketing Telemetry Snapshot Exposure #2",
+    "description": "Surfaces exposed Marketing telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/telemetry-snapshot-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-marketing-03",
+    "name": "Marketing Telemetry Snapshot Exposure #3",
+    "description": "Surfaces exposed Marketing telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/marketing/telemetry-snapshot-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-marketing-04",
+    "name": "Marketing Telemetry Snapshot Exposure #4",
+    "description": "Surfaces exposed Marketing telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/telemetry-snapshot-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-marketing-05",
+    "name": "Marketing Telemetry Snapshot Exposure #5",
+    "description": "Surfaces exposed Marketing telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/telemetry-snapshot-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-marketing-01",
+    "name": "Marketing Debug Trace Log Leak #1",
+    "description": "Detects leaked Marketing debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/debug-trace-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-marketing-02",
+    "name": "Marketing Debug Trace Log Leak #2",
+    "description": "Detects leaked Marketing debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/debug-trace-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-marketing-03",
+    "name": "Marketing Debug Trace Log Leak #3",
+    "description": "Detects leaked Marketing debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/marketing/debug-trace-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-marketing-04",
+    "name": "Marketing Debug Trace Log Leak #4",
+    "description": "Detects leaked Marketing debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/debug-trace-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-marketing-05",
+    "name": "Marketing Debug Trace Log Leak #5",
+    "description": "Detects leaked Marketing debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/debug-trace-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-marketing-01",
+    "name": "Marketing Database Backup Exposure #1",
+    "description": "Finds exposed Marketing database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/db-backup-01.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-marketing-02",
+    "name": "Marketing Database Backup Exposure #2",
+    "description": "Finds exposed Marketing database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/db-backup-02.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-marketing-03",
+    "name": "Marketing Database Backup Exposure #3",
+    "description": "Finds exposed Marketing database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/db-backup-03.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-marketing-04",
+    "name": "Marketing Database Backup Exposure #4",
+    "description": "Finds exposed Marketing database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/db-backup-04.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-marketing-05",
+    "name": "Marketing Database Backup Exposure #5",
+    "description": "Finds exposed Marketing database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/db-backup-05.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-marketing-01",
+    "name": "Marketing Compliance Report Leak #1",
+    "description": "Detects leaked Marketing compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/compliance-report-01.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-marketing-02",
+    "name": "Marketing Compliance Report Leak #2",
+    "description": "Detects leaked Marketing compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/compliance-report-02.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-marketing-03",
+    "name": "Marketing Compliance Report Leak #3",
+    "description": "Detects leaked Marketing compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/marketing/compliance-report-03.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-marketing-04",
+    "name": "Marketing Compliance Report Leak #4",
+    "description": "Detects leaked Marketing compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/compliance-report-04.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-marketing-05",
+    "name": "Marketing Compliance Report Leak #5",
+    "description": "Detects leaked Marketing compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/compliance-report-05.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-operations-01",
+    "name": "Operations Token Cache Dump #1",
+    "description": "Detects exposed Operations token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/token-cache-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-operations-02",
+    "name": "Operations Token Cache Dump #2",
+    "description": "Detects exposed Operations token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/token-cache-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-operations-03",
+    "name": "Operations Token Cache Dump #3",
+    "description": "Detects exposed Operations token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/token-cache-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-operations-04",
+    "name": "Operations Token Cache Dump #4",
+    "description": "Detects exposed Operations token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/token-cache-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-operations-05",
+    "name": "Operations Token Cache Dump #5",
+    "description": "Detects exposed Operations token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/token-cache-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-operations-01",
+    "name": "Operations Session Ledger Leak #1",
+    "description": "Catches leaked Operations session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/sessions-ledger-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-operations-02",
+    "name": "Operations Session Ledger Leak #2",
+    "description": "Catches leaked Operations session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/sessions-ledger-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-operations-03",
+    "name": "Operations Session Ledger Leak #3",
+    "description": "Catches leaked Operations session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/sessions-ledger-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-operations-04",
+    "name": "Operations Session Ledger Leak #4",
+    "description": "Catches leaked Operations session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/sessions-ledger-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-operations-05",
+    "name": "Operations Session Ledger Leak #5",
+    "description": "Catches leaked Operations session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/sessions-ledger-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-operations-01",
+    "name": "Operations Config Export Exposure #1",
+    "description": "Finds world-readable Operations configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/config-export-01.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-operations-02",
+    "name": "Operations Config Export Exposure #2",
+    "description": "Finds world-readable Operations configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/config-export-02.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-operations-03",
+    "name": "Operations Config Export Exposure #3",
+    "description": "Finds world-readable Operations configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/config-export-03.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-operations-04",
+    "name": "Operations Config Export Exposure #4",
+    "description": "Finds world-readable Operations configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/config-export-04.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-operations-05",
+    "name": "Operations Config Export Exposure #5",
+    "description": "Finds world-readable Operations configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/config-export-05.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-operations-01",
+    "name": "Operations User Dump Exposure #1",
+    "description": "Detects exposed Operations user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/user-dump-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-operations-02",
+    "name": "Operations User Dump Exposure #2",
+    "description": "Detects exposed Operations user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/user-dump-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-operations-03",
+    "name": "Operations User Dump Exposure #3",
+    "description": "Detects exposed Operations user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/operations/user-dump-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-operations-04",
+    "name": "Operations User Dump Exposure #4",
+    "description": "Detects exposed Operations user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/user-dump-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-operations-05",
+    "name": "Operations User Dump Exposure #5",
+    "description": "Detects exposed Operations user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/user-dump-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-operations-01",
+    "name": "Operations Billing Export Exposure #1",
+    "description": "Identifies Operations billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/billing-export-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-operations-02",
+    "name": "Operations Billing Export Exposure #2",
+    "description": "Identifies Operations billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/billing-export-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-operations-03",
+    "name": "Operations Billing Export Exposure #3",
+    "description": "Identifies Operations billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/operations/billing-export-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-operations-04",
+    "name": "Operations Billing Export Exposure #4",
+    "description": "Identifies Operations billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/billing-export-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-operations-05",
+    "name": "Operations Billing Export Exposure #5",
+    "description": "Identifies Operations billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/billing-export-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-operations-01",
+    "name": "Operations Webhook Registry Leak #1",
+    "description": "Detects leaked Operations webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/webhooks-registry-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-operations-02",
+    "name": "Operations Webhook Registry Leak #2",
+    "description": "Detects leaked Operations webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/webhooks-registry-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-operations-03",
+    "name": "Operations Webhook Registry Leak #3",
+    "description": "Detects leaked Operations webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/webhooks-registry-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-operations-04",
+    "name": "Operations Webhook Registry Leak #4",
+    "description": "Detects leaked Operations webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/webhooks-registry-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-operations-05",
+    "name": "Operations Webhook Registry Leak #5",
+    "description": "Detects leaked Operations webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/webhooks-registry-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-operations-01",
+    "name": "Operations Telemetry Snapshot Exposure #1",
+    "description": "Surfaces exposed Operations telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/telemetry-snapshot-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-operations-02",
+    "name": "Operations Telemetry Snapshot Exposure #2",
+    "description": "Surfaces exposed Operations telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/telemetry-snapshot-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-operations-03",
+    "name": "Operations Telemetry Snapshot Exposure #3",
+    "description": "Surfaces exposed Operations telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/operations/telemetry-snapshot-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-operations-04",
+    "name": "Operations Telemetry Snapshot Exposure #4",
+    "description": "Surfaces exposed Operations telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/telemetry-snapshot-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-operations-05",
+    "name": "Operations Telemetry Snapshot Exposure #5",
+    "description": "Surfaces exposed Operations telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/telemetry-snapshot-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-operations-01",
+    "name": "Operations Debug Trace Log Leak #1",
+    "description": "Detects leaked Operations debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/debug-trace-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-operations-02",
+    "name": "Operations Debug Trace Log Leak #2",
+    "description": "Detects leaked Operations debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/debug-trace-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-operations-03",
+    "name": "Operations Debug Trace Log Leak #3",
+    "description": "Detects leaked Operations debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/operations/debug-trace-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-operations-04",
+    "name": "Operations Debug Trace Log Leak #4",
+    "description": "Detects leaked Operations debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/debug-trace-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-operations-05",
+    "name": "Operations Debug Trace Log Leak #5",
+    "description": "Detects leaked Operations debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/debug-trace-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-operations-01",
+    "name": "Operations Database Backup Exposure #1",
+    "description": "Finds exposed Operations database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/db-backup-01.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-operations-02",
+    "name": "Operations Database Backup Exposure #2",
+    "description": "Finds exposed Operations database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/db-backup-02.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-operations-03",
+    "name": "Operations Database Backup Exposure #3",
+    "description": "Finds exposed Operations database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/db-backup-03.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-operations-04",
+    "name": "Operations Database Backup Exposure #4",
+    "description": "Finds exposed Operations database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/db-backup-04.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-operations-05",
+    "name": "Operations Database Backup Exposure #5",
+    "description": "Finds exposed Operations database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/db-backup-05.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-operations-01",
+    "name": "Operations Compliance Report Leak #1",
+    "description": "Detects leaked Operations compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/compliance-report-01.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-operations-02",
+    "name": "Operations Compliance Report Leak #2",
+    "description": "Detects leaked Operations compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/compliance-report-02.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-operations-03",
+    "name": "Operations Compliance Report Leak #3",
+    "description": "Detects leaked Operations compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/operations/compliance-report-03.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-operations-04",
+    "name": "Operations Compliance Report Leak #4",
+    "description": "Detects leaked Operations compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/compliance-report-04.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-operations-05",
+    "name": "Operations Compliance Report Leak #5",
+    "description": "Detects leaked Operations compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/compliance-report-05.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-product-01",
+    "name": "Product Token Cache Dump #1",
+    "description": "Detects exposed Product token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/token-cache-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-product-02",
+    "name": "Product Token Cache Dump #2",
+    "description": "Detects exposed Product token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/token-cache-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-product-03",
+    "name": "Product Token Cache Dump #3",
+    "description": "Detects exposed Product token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/token-cache-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-product-04",
+    "name": "Product Token Cache Dump #4",
+    "description": "Detects exposed Product token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/token-cache-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-product-05",
+    "name": "Product Token Cache Dump #5",
+    "description": "Detects exposed Product token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/token-cache-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-product-01",
+    "name": "Product Session Ledger Leak #1",
+    "description": "Catches leaked Product session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/sessions-ledger-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-product-02",
+    "name": "Product Session Ledger Leak #2",
+    "description": "Catches leaked Product session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/sessions-ledger-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-product-03",
+    "name": "Product Session Ledger Leak #3",
+    "description": "Catches leaked Product session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/sessions-ledger-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-product-04",
+    "name": "Product Session Ledger Leak #4",
+    "description": "Catches leaked Product session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/sessions-ledger-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-product-05",
+    "name": "Product Session Ledger Leak #5",
+    "description": "Catches leaked Product session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/sessions-ledger-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-product-01",
+    "name": "Product Config Export Exposure #1",
+    "description": "Finds world-readable Product configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/config-export-01.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-product-02",
+    "name": "Product Config Export Exposure #2",
+    "description": "Finds world-readable Product configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/config-export-02.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-product-03",
+    "name": "Product Config Export Exposure #3",
+    "description": "Finds world-readable Product configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/config-export-03.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-product-04",
+    "name": "Product Config Export Exposure #4",
+    "description": "Finds world-readable Product configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/config-export-04.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-product-05",
+    "name": "Product Config Export Exposure #5",
+    "description": "Finds world-readable Product configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/config-export-05.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-product-01",
+    "name": "Product User Dump Exposure #1",
+    "description": "Detects exposed Product user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/user-dump-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-product-02",
+    "name": "Product User Dump Exposure #2",
+    "description": "Detects exposed Product user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/user-dump-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-product-03",
+    "name": "Product User Dump Exposure #3",
+    "description": "Detects exposed Product user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/product/user-dump-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-product-04",
+    "name": "Product User Dump Exposure #4",
+    "description": "Detects exposed Product user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/user-dump-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-product-05",
+    "name": "Product User Dump Exposure #5",
+    "description": "Detects exposed Product user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/user-dump-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-product-01",
+    "name": "Product Billing Export Exposure #1",
+    "description": "Identifies Product billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/billing-export-01.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-product-02",
+    "name": "Product Billing Export Exposure #2",
+    "description": "Identifies Product billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/billing-export-02.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-product-03",
+    "name": "Product Billing Export Exposure #3",
+    "description": "Identifies Product billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/product/billing-export-03.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-product-04",
+    "name": "Product Billing Export Exposure #4",
+    "description": "Identifies Product billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/billing-export-04.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-product-05",
+    "name": "Product Billing Export Exposure #5",
+    "description": "Identifies Product billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/billing-export-05.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-product-01",
+    "name": "Product Webhook Registry Leak #1",
+    "description": "Detects leaked Product webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/webhooks-registry-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-product-02",
+    "name": "Product Webhook Registry Leak #2",
+    "description": "Detects leaked Product webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/webhooks-registry-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-product-03",
+    "name": "Product Webhook Registry Leak #3",
+    "description": "Detects leaked Product webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/webhooks-registry-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-product-04",
+    "name": "Product Webhook Registry Leak #4",
+    "description": "Detects leaked Product webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/webhooks-registry-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-product-05",
+    "name": "Product Webhook Registry Leak #5",
+    "description": "Detects leaked Product webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/webhooks-registry-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-product-01",
+    "name": "Product Telemetry Snapshot Exposure #1",
+    "description": "Surfaces exposed Product telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/telemetry-snapshot-01.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-product-02",
+    "name": "Product Telemetry Snapshot Exposure #2",
+    "description": "Surfaces exposed Product telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/telemetry-snapshot-02.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-product-03",
+    "name": "Product Telemetry Snapshot Exposure #3",
+    "description": "Surfaces exposed Product telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/product/telemetry-snapshot-03.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-product-04",
+    "name": "Product Telemetry Snapshot Exposure #4",
+    "description": "Surfaces exposed Product telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/telemetry-snapshot-04.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-product-05",
+    "name": "Product Telemetry Snapshot Exposure #5",
+    "description": "Surfaces exposed Product telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/telemetry-snapshot-05.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-product-01",
+    "name": "Product Debug Trace Log Leak #1",
+    "description": "Detects leaked Product debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/debug-trace-01.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-product-02",
+    "name": "Product Debug Trace Log Leak #2",
+    "description": "Detects leaked Product debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/debug-trace-02.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-product-03",
+    "name": "Product Debug Trace Log Leak #3",
+    "description": "Detects leaked Product debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/product/debug-trace-03.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-product-04",
+    "name": "Product Debug Trace Log Leak #4",
+    "description": "Detects leaked Product debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/debug-trace-04.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-product-05",
+    "name": "Product Debug Trace Log Leak #5",
+    "description": "Detects leaked Product debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/debug-trace-05.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-product-01",
+    "name": "Product Database Backup Exposure #1",
+    "description": "Finds exposed Product database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/db-backup-01.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-product-02",
+    "name": "Product Database Backup Exposure #2",
+    "description": "Finds exposed Product database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/db-backup-02.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-product-03",
+    "name": "Product Database Backup Exposure #3",
+    "description": "Finds exposed Product database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/db-backup-03.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-product-04",
+    "name": "Product Database Backup Exposure #4",
+    "description": "Finds exposed Product database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/db-backup-04.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-product-05",
+    "name": "Product Database Backup Exposure #5",
+    "description": "Finds exposed Product database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/db-backup-05.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-product-01",
+    "name": "Product Compliance Report Leak #1",
+    "description": "Detects leaked Product compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/compliance-report-01.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-product-02",
+    "name": "Product Compliance Report Leak #2",
+    "description": "Detects leaked Product compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/compliance-report-02.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-product-03",
+    "name": "Product Compliance Report Leak #3",
+    "description": "Detects leaked Product compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/product/compliance-report-03.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-product-04",
+    "name": "Product Compliance Report Leak #4",
+    "description": "Detects leaked Product compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/compliance-report-04.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-product-05",
+    "name": "Product Compliance Report Leak #5",
+    "description": "Detects leaked Product compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/compliance-report-05.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "product"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- add a helper script that can bulk-generate nuclei-style API regex templates
- extend the default automation template catalog with 1,000 additional API scanning rules derived from the helper

## Testing
- python -m compileall automations/build_api_regex_rules.py

------
https://chatgpt.com/codex/tasks/task_b_68ce9dae3f788329a9f60d03df59a782