### PR TITLE
Expand automation regex coverage

### DIFF
--- a/automations/regex_sets/billing-export.json
+++ b/automations/regex_sets/billing-export.json
@@ -6,801 +6,1601 @@
     {
       "template_id": "api-regex-billing-export-access-management-01",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-access-management-02",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-access-management-03",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-access-management-04",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-access-management-05",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-access-management-06",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-access-management-07",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-access-management-08",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-access-management-09",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-access-management-10",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-accounting-01",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-accounting-02",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-accounting-03",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-accounting-04",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-accounting-05",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-accounting-06",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-accounting-07",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-accounting-08",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-accounting-09",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-accounting-10",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-analytics-01",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-analytics-02",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-analytics-03",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-analytics-04",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-analytics-05",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-analytics-06",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-analytics-07",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-analytics-08",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-analytics-09",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-analytics-10",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-audit-01",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-audit-02",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-audit-03",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-audit-04",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-audit-05",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-audit-06",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-audit-07",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-audit-08",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-audit-09",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-audit-10",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-billing-01",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-billing-02",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-billing-03",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-billing-04",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-billing-05",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-billing-06",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-billing-07",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-billing-08",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-billing-09",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-billing-10",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-business-intelligence-01",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-business-intelligence-02",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-business-intelligence-03",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-business-intelligence-04",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-business-intelligence-05",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-business-intelligence-06",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-business-intelligence-07",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-business-intelligence-08",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-business-intelligence-09",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-business-intelligence-10",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-cloud-ops-01",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-cloud-ops-02",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-cloud-ops-03",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-cloud-ops-04",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-cloud-ops-05",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-cloud-ops-06",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-cloud-ops-07",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-cloud-ops-08",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-cloud-ops-09",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-cloud-ops-10",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-collaboration-01",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-collaboration-02",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-collaboration-03",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-collaboration-04",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-collaboration-05",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-collaboration-06",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-collaboration-07",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-collaboration-08",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-collaboration-09",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-collaboration-10",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-commerce-01",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-commerce-02",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-commerce-03",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-commerce-04",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-commerce-05",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-commerce-06",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-commerce-07",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-commerce-08",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-commerce-09",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-commerce-10",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-compliance-01",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-compliance-02",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-compliance-03",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-compliance-04",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-compliance-05",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-compliance-06",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-compliance-07",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-compliance-08",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-compliance-09",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-compliance-10",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-customer-success-01",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-customer-success-02",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-customer-success-03",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-customer-success-04",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-customer-success-05",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-customer-success-06",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-customer-success-07",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-customer-success-08",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-customer-success-09",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-customer-success-10",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-devops-01",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-devops-02",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-devops-03",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-devops-04",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-devops-05",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-devops-06",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-devops-07",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-devops-08",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-devops-09",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-devops-10",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-finance-01",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-finance-02",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-finance-03",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-finance-04",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-finance-05",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-finance-06",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-finance-07",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-finance-08",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-finance-09",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-finance-10",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-governance-01",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-governance-02",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-governance-03",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-governance-04",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-governance-05",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-governance-06",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-governance-07",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-governance-08",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-governance-09",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-governance-10",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-identity-01",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-identity-02",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-identity-03",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-identity-04",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-identity-05",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-identity-06",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-identity-07",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-identity-08",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-identity-09",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-identity-10",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-infrastructure-01",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-infrastructure-02",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-infrastructure-03",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-infrastructure-04",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-infrastructure-05",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-infrastructure-06",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-infrastructure-07",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-infrastructure-08",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-infrastructure-09",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-infrastructure-10",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-logistics-01",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-logistics-02",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-logistics-03",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-logistics-04",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-logistics-05",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-logistics-06",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-logistics-07",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-logistics-08",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-logistics-09",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-logistics-10",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-marketing-01",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-marketing-02",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-marketing-03",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-marketing-04",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-marketing-05",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-marketing-06",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-marketing-07",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-marketing-08",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-marketing-09",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-marketing-10",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-operations-01",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-operations-02",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-operations-03",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-operations-04",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-operations-05",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-operations-06",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-operations-07",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-operations-08",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-operations-09",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-operations-10",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-product-01",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-product-02",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-product-03",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-product-04",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
       ]
     },
     {
       "template_id": "api-regex-billing-export-product-05",
       "regex": [
+        "(?i)invoice",
         "(?i)amount",
-        "(?i)currency",
-        "(?i)invoice"
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-product-06",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-product-07",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-product-08",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-product-09",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    {
+      "template_id": "api-regex-billing-export-product-10",
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
       ]
     }
   ]

--- a/automations/regex_sets/compliance-report.json
+++ b/automations/regex_sets/compliance-report.json
@@ -44,6 +44,46 @@
       ]
     },
     {
+      "template_id": "api-regex-compliance-report-access-management-06",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-access-management-07",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-access-management-08",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-access-management-09",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-access-management-10",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
       "template_id": "api-regex-compliance-report-accounting-01",
       "regex": [
         "(?i)compliance",
@@ -77,6 +117,46 @@
     },
     {
       "template_id": "api-regex-compliance-report-accounting-05",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-accounting-06",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-accounting-07",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-accounting-08",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-accounting-09",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-accounting-10",
       "regex": [
         "(?i)compliance",
         "(?i)control",
@@ -124,6 +204,46 @@
       ]
     },
     {
+      "template_id": "api-regex-compliance-report-analytics-06",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-analytics-07",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-analytics-08",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-analytics-09",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-analytics-10",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
       "template_id": "api-regex-compliance-report-audit-01",
       "regex": [
         "(?i)compliance",
@@ -157,6 +277,46 @@
     },
     {
       "template_id": "api-regex-compliance-report-audit-05",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-audit-06",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-audit-07",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-audit-08",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-audit-09",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-audit-10",
       "regex": [
         "(?i)compliance",
         "(?i)control",
@@ -204,6 +364,46 @@
       ]
     },
     {
+      "template_id": "api-regex-compliance-report-billing-06",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-billing-07",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-billing-08",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-billing-09",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-billing-10",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
       "template_id": "api-regex-compliance-report-business-intelligence-01",
       "regex": [
         "(?i)compliance",
@@ -237,6 +437,46 @@
     },
     {
       "template_id": "api-regex-compliance-report-business-intelligence-05",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-business-intelligence-06",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-business-intelligence-07",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-business-intelligence-08",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-business-intelligence-09",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-business-intelligence-10",
       "regex": [
         "(?i)compliance",
         "(?i)control",
@@ -284,6 +524,46 @@
       ]
     },
     {
+      "template_id": "api-regex-compliance-report-cloud-ops-06",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-cloud-ops-07",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-cloud-ops-08",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-cloud-ops-09",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-cloud-ops-10",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
       "template_id": "api-regex-compliance-report-collaboration-01",
       "regex": [
         "(?i)compliance",
@@ -317,6 +597,46 @@
     },
     {
       "template_id": "api-regex-compliance-report-collaboration-05",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-collaboration-06",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-collaboration-07",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-collaboration-08",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-collaboration-09",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-collaboration-10",
       "regex": [
         "(?i)compliance",
         "(?i)control",
@@ -364,6 +684,46 @@
       ]
     },
     {
+      "template_id": "api-regex-compliance-report-commerce-06",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-commerce-07",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-commerce-08",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-commerce-09",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-commerce-10",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
       "template_id": "api-regex-compliance-report-compliance-01",
       "regex": [
         "(?i)compliance",
@@ -397,6 +757,46 @@
     },
     {
       "template_id": "api-regex-compliance-report-compliance-05",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-compliance-06",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-compliance-07",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-compliance-08",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-compliance-09",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-compliance-10",
       "regex": [
         "(?i)compliance",
         "(?i)control",
@@ -444,6 +844,46 @@
       ]
     },
     {
+      "template_id": "api-regex-compliance-report-customer-success-06",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-customer-success-07",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-customer-success-08",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-customer-success-09",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-customer-success-10",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
       "template_id": "api-regex-compliance-report-devops-01",
       "regex": [
         "(?i)compliance",
@@ -477,6 +917,46 @@
     },
     {
       "template_id": "api-regex-compliance-report-devops-05",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-devops-06",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-devops-07",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-devops-08",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-devops-09",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-devops-10",
       "regex": [
         "(?i)compliance",
         "(?i)control",
@@ -524,6 +1004,46 @@
       ]
     },
     {
+      "template_id": "api-regex-compliance-report-finance-06",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-finance-07",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-finance-08",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-finance-09",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-finance-10",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
       "template_id": "api-regex-compliance-report-governance-01",
       "regex": [
         "(?i)compliance",
@@ -557,6 +1077,46 @@
     },
     {
       "template_id": "api-regex-compliance-report-governance-05",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-governance-06",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-governance-07",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-governance-08",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-governance-09",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-governance-10",
       "regex": [
         "(?i)compliance",
         "(?i)control",
@@ -604,6 +1164,46 @@
       ]
     },
     {
+      "template_id": "api-regex-compliance-report-identity-06",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-identity-07",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-identity-08",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-identity-09",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-identity-10",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
       "template_id": "api-regex-compliance-report-infrastructure-01",
       "regex": [
         "(?i)compliance",
@@ -637,6 +1237,46 @@
     },
     {
       "template_id": "api-regex-compliance-report-infrastructure-05",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-infrastructure-06",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-infrastructure-07",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-infrastructure-08",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-infrastructure-09",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-infrastructure-10",
       "regex": [
         "(?i)compliance",
         "(?i)control",
@@ -684,6 +1324,46 @@
       ]
     },
     {
+      "template_id": "api-regex-compliance-report-logistics-06",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-logistics-07",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-logistics-08",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-logistics-09",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-logistics-10",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
       "template_id": "api-regex-compliance-report-marketing-01",
       "regex": [
         "(?i)compliance",
@@ -717,6 +1397,46 @@
     },
     {
       "template_id": "api-regex-compliance-report-marketing-05",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-marketing-06",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-marketing-07",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-marketing-08",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-marketing-09",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-marketing-10",
       "regex": [
         "(?i)compliance",
         "(?i)control",
@@ -764,6 +1484,46 @@
       ]
     },
     {
+      "template_id": "api-regex-compliance-report-operations-06",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-operations-07",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-operations-08",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-operations-09",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-operations-10",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
       "template_id": "api-regex-compliance-report-product-01",
       "regex": [
         "(?i)compliance",
@@ -797,6 +1557,46 @@
     },
     {
       "template_id": "api-regex-compliance-report-product-05",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-product-06",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-product-07",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-product-08",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-product-09",
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    {
+      "template_id": "api-regex-compliance-report-product-10",
       "regex": [
         "(?i)compliance",
         "(?i)control",

--- a/automations/regex_sets/config-export.json
+++ b/automations/regex_sets/config-export.json
@@ -44,6 +44,46 @@
       ]
     },
     {
+      "template_id": "api-regex-config-export-access-management-06",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-access-management-07",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-access-management-08",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-access-management-09",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-access-management-10",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
       "template_id": "api-regex-config-export-accounting-01",
       "regex": [
         "(?i)config",
@@ -77,6 +117,46 @@
     },
     {
       "template_id": "api-regex-config-export-accounting-05",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-accounting-06",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-accounting-07",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-accounting-08",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-accounting-09",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-accounting-10",
       "regex": [
         "(?i)config",
         "(?i)environment",
@@ -124,6 +204,46 @@
       ]
     },
     {
+      "template_id": "api-regex-config-export-analytics-06",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-analytics-07",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-analytics-08",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-analytics-09",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-analytics-10",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
       "template_id": "api-regex-config-export-audit-01",
       "regex": [
         "(?i)config",
@@ -157,6 +277,46 @@
     },
     {
       "template_id": "api-regex-config-export-audit-05",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-audit-06",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-audit-07",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-audit-08",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-audit-09",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-audit-10",
       "regex": [
         "(?i)config",
         "(?i)environment",
@@ -204,6 +364,46 @@
       ]
     },
     {
+      "template_id": "api-regex-config-export-billing-06",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-billing-07",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-billing-08",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-billing-09",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-billing-10",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
       "template_id": "api-regex-config-export-business-intelligence-01",
       "regex": [
         "(?i)config",
@@ -237,6 +437,46 @@
     },
     {
       "template_id": "api-regex-config-export-business-intelligence-05",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-business-intelligence-06",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-business-intelligence-07",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-business-intelligence-08",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-business-intelligence-09",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-business-intelligence-10",
       "regex": [
         "(?i)config",
         "(?i)environment",
@@ -284,6 +524,46 @@
       ]
     },
     {
+      "template_id": "api-regex-config-export-cloud-ops-06",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-cloud-ops-07",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-cloud-ops-08",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-cloud-ops-09",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-cloud-ops-10",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
       "template_id": "api-regex-config-export-collaboration-01",
       "regex": [
         "(?i)config",
@@ -317,6 +597,46 @@
     },
     {
       "template_id": "api-regex-config-export-collaboration-05",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-collaboration-06",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-collaboration-07",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-collaboration-08",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-collaboration-09",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-collaboration-10",
       "regex": [
         "(?i)config",
         "(?i)environment",
@@ -364,6 +684,46 @@
       ]
     },
     {
+      "template_id": "api-regex-config-export-commerce-06",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-commerce-07",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-commerce-08",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-commerce-09",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-commerce-10",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
       "template_id": "api-regex-config-export-compliance-01",
       "regex": [
         "(?i)config",
@@ -397,6 +757,46 @@
     },
     {
       "template_id": "api-regex-config-export-compliance-05",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-compliance-06",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-compliance-07",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-compliance-08",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-compliance-09",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-compliance-10",
       "regex": [
         "(?i)config",
         "(?i)environment",
@@ -444,6 +844,46 @@
       ]
     },
     {
+      "template_id": "api-regex-config-export-customer-success-06",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-customer-success-07",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-customer-success-08",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-customer-success-09",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-customer-success-10",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
       "template_id": "api-regex-config-export-devops-01",
       "regex": [
         "(?i)config",
@@ -477,6 +917,46 @@
     },
     {
       "template_id": "api-regex-config-export-devops-05",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-devops-06",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-devops-07",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-devops-08",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-devops-09",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-devops-10",
       "regex": [
         "(?i)config",
         "(?i)environment",
@@ -524,6 +1004,46 @@
       ]
     },
     {
+      "template_id": "api-regex-config-export-finance-06",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-finance-07",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-finance-08",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-finance-09",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-finance-10",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
       "template_id": "api-regex-config-export-governance-01",
       "regex": [
         "(?i)config",
@@ -557,6 +1077,46 @@
     },
     {
       "template_id": "api-regex-config-export-governance-05",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-governance-06",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-governance-07",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-governance-08",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-governance-09",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-governance-10",
       "regex": [
         "(?i)config",
         "(?i)environment",
@@ -604,6 +1164,46 @@
       ]
     },
     {
+      "template_id": "api-regex-config-export-identity-06",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-identity-07",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-identity-08",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-identity-09",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-identity-10",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
       "template_id": "api-regex-config-export-infrastructure-01",
       "regex": [
         "(?i)config",
@@ -637,6 +1237,46 @@
     },
     {
       "template_id": "api-regex-config-export-infrastructure-05",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-infrastructure-06",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-infrastructure-07",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-infrastructure-08",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-infrastructure-09",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-infrastructure-10",
       "regex": [
         "(?i)config",
         "(?i)environment",
@@ -684,6 +1324,46 @@
       ]
     },
     {
+      "template_id": "api-regex-config-export-logistics-06",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-logistics-07",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-logistics-08",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-logistics-09",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-logistics-10",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
       "template_id": "api-regex-config-export-marketing-01",
       "regex": [
         "(?i)config",
@@ -717,6 +1397,46 @@
     },
     {
       "template_id": "api-regex-config-export-marketing-05",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-marketing-06",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-marketing-07",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-marketing-08",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-marketing-09",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-marketing-10",
       "regex": [
         "(?i)config",
         "(?i)environment",
@@ -764,6 +1484,46 @@
       ]
     },
     {
+      "template_id": "api-regex-config-export-operations-06",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-operations-07",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-operations-08",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-operations-09",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-operations-10",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
       "template_id": "api-regex-config-export-product-01",
       "regex": [
         "(?i)config",
@@ -797,6 +1557,46 @@
     },
     {
       "template_id": "api-regex-config-export-product-05",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-product-06",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-product-07",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-product-08",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-product-09",
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    {
+      "template_id": "api-regex-config-export-product-10",
       "regex": [
         "(?i)config",
         "(?i)environment",

--- a/automations/regex_sets/database-backup.json
+++ b/automations/regex_sets/database-backup.json
@@ -6,801 +6,1601 @@
     {
       "template_id": "api-regex-database-backup-access-management-01",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-access-management-02",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-access-management-03",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-access-management-04",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-access-management-05",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-access-management-06",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-access-management-07",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-access-management-08",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-access-management-09",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-access-management-10",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-accounting-01",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-accounting-02",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-accounting-03",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-accounting-04",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-accounting-05",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-accounting-06",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-accounting-07",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-accounting-08",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-accounting-09",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-accounting-10",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-analytics-01",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-analytics-02",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-analytics-03",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-analytics-04",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-analytics-05",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-analytics-06",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-analytics-07",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-analytics-08",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-analytics-09",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-analytics-10",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-audit-01",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-audit-02",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-audit-03",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-audit-04",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-audit-05",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-audit-06",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-audit-07",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-audit-08",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-audit-09",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-audit-10",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-billing-01",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-billing-02",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-billing-03",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-billing-04",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-billing-05",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-billing-06",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-billing-07",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-billing-08",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-billing-09",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-billing-10",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-business-intelligence-01",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-business-intelligence-02",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-business-intelligence-03",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-business-intelligence-04",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-business-intelligence-05",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-business-intelligence-06",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-business-intelligence-07",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-business-intelligence-08",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-business-intelligence-09",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-business-intelligence-10",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-cloud-ops-01",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-cloud-ops-02",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-cloud-ops-03",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-cloud-ops-04",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-cloud-ops-05",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-cloud-ops-06",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-cloud-ops-07",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-cloud-ops-08",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-cloud-ops-09",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-cloud-ops-10",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-collaboration-01",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-collaboration-02",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-collaboration-03",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-collaboration-04",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-collaboration-05",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-collaboration-06",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-collaboration-07",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-collaboration-08",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-collaboration-09",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-collaboration-10",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-commerce-01",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-commerce-02",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-commerce-03",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-commerce-04",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-commerce-05",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-commerce-06",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-commerce-07",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-commerce-08",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-commerce-09",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-commerce-10",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-compliance-01",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-compliance-02",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-compliance-03",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-compliance-04",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-compliance-05",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-compliance-06",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-compliance-07",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-compliance-08",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-compliance-09",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-compliance-10",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-customer-success-01",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-customer-success-02",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-customer-success-03",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-customer-success-04",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-customer-success-05",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-customer-success-06",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-customer-success-07",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-customer-success-08",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-customer-success-09",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-customer-success-10",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-devops-01",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-devops-02",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-devops-03",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-devops-04",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-devops-05",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-devops-06",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-devops-07",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-devops-08",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-devops-09",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-devops-10",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-finance-01",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-finance-02",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-finance-03",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-finance-04",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-finance-05",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-finance-06",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-finance-07",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-finance-08",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-finance-09",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-finance-10",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-governance-01",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-governance-02",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-governance-03",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-governance-04",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-governance-05",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-governance-06",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-governance-07",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-governance-08",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-governance-09",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-governance-10",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-identity-01",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-identity-02",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-identity-03",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-identity-04",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-identity-05",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-identity-06",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-identity-07",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-identity-08",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-identity-09",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-identity-10",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-infrastructure-01",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-infrastructure-02",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-infrastructure-03",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-infrastructure-04",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-infrastructure-05",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-infrastructure-06",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-infrastructure-07",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-infrastructure-08",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-infrastructure-09",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-infrastructure-10",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-logistics-01",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-logistics-02",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-logistics-03",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-logistics-04",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-logistics-05",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-logistics-06",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-logistics-07",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-logistics-08",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-logistics-09",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-logistics-10",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-marketing-01",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-marketing-02",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-marketing-03",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-marketing-04",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-marketing-05",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-marketing-06",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-marketing-07",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-marketing-08",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-marketing-09",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-marketing-10",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-operations-01",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-operations-02",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-operations-03",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-operations-04",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-operations-05",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-operations-06",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-operations-07",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-operations-08",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-operations-09",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-operations-10",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-product-01",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-product-02",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-product-03",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-product-04",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
       ]
     },
     {
       "template_id": "api-regex-database-backup-product-05",
       "regex": [
-        "(?i)api_key",
         "(?i)insert",
-        "(?i)password"
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-product-06",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-product-07",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-product-08",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-product-09",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    {
+      "template_id": "api-regex-database-backup-product-10",
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
       ]
     }
   ]

--- a/automations/regex_sets/debug-trace.json
+++ b/automations/regex_sets/debug-trace.json
@@ -6,801 +6,1601 @@
     {
       "template_id": "api-regex-debug-trace-access-management-01",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-access-management-02",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-access-management-03",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-access-management-04",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-access-management-05",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-access-management-06",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-access-management-07",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-access-management-08",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-access-management-09",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-access-management-10",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-accounting-01",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-accounting-02",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-accounting-03",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-accounting-04",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-accounting-05",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-accounting-06",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-accounting-07",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-accounting-08",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-accounting-09",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-accounting-10",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-analytics-01",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-analytics-02",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-analytics-03",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-analytics-04",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-analytics-05",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-analytics-06",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-analytics-07",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-analytics-08",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-analytics-09",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-analytics-10",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-audit-01",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-audit-02",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-audit-03",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-audit-04",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-audit-05",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-audit-06",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-audit-07",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-audit-08",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-audit-09",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-audit-10",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-billing-01",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-billing-02",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-billing-03",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-billing-04",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-billing-05",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-billing-06",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-billing-07",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-billing-08",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-billing-09",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-billing-10",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-business-intelligence-01",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-business-intelligence-02",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-business-intelligence-03",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-business-intelligence-04",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-business-intelligence-05",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-business-intelligence-06",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-business-intelligence-07",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-business-intelligence-08",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-business-intelligence-09",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-business-intelligence-10",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-cloud-ops-01",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-cloud-ops-02",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-cloud-ops-03",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-cloud-ops-04",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-cloud-ops-05",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-cloud-ops-06",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-cloud-ops-07",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-cloud-ops-08",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-cloud-ops-09",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-cloud-ops-10",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-collaboration-01",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-collaboration-02",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-collaboration-03",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-collaboration-04",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-collaboration-05",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-collaboration-06",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-collaboration-07",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-collaboration-08",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-collaboration-09",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-collaboration-10",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-commerce-01",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-commerce-02",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-commerce-03",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-commerce-04",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-commerce-05",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-commerce-06",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-commerce-07",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-commerce-08",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-commerce-09",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-commerce-10",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-compliance-01",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-compliance-02",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-compliance-03",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-compliance-04",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-compliance-05",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-compliance-06",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-compliance-07",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-compliance-08",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-compliance-09",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-compliance-10",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-customer-success-01",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-customer-success-02",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-customer-success-03",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-customer-success-04",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-customer-success-05",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-customer-success-06",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-customer-success-07",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-customer-success-08",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-customer-success-09",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-customer-success-10",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-devops-01",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-devops-02",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-devops-03",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-devops-04",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-devops-05",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-devops-06",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-devops-07",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-devops-08",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-devops-09",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-devops-10",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-finance-01",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-finance-02",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-finance-03",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-finance-04",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-finance-05",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-finance-06",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-finance-07",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-finance-08",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-finance-09",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-finance-10",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-governance-01",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-governance-02",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-governance-03",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-governance-04",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-governance-05",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-governance-06",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-governance-07",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-governance-08",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-governance-09",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-governance-10",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-identity-01",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-identity-02",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-identity-03",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-identity-04",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-identity-05",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-identity-06",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-identity-07",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-identity-08",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-identity-09",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-identity-10",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-infrastructure-01",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-infrastructure-02",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-infrastructure-03",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-infrastructure-04",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-infrastructure-05",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-infrastructure-06",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-infrastructure-07",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-infrastructure-08",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-infrastructure-09",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-infrastructure-10",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-logistics-01",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-logistics-02",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-logistics-03",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-logistics-04",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-logistics-05",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-logistics-06",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-logistics-07",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-logistics-08",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-logistics-09",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-logistics-10",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-marketing-01",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-marketing-02",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-marketing-03",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-marketing-04",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-marketing-05",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-marketing-06",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-marketing-07",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-marketing-08",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-marketing-09",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-marketing-10",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-operations-01",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-operations-02",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-operations-03",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-operations-04",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-operations-05",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-operations-06",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-operations-07",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-operations-08",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-operations-09",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-operations-10",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-product-01",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-product-02",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-product-03",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-product-04",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
       ]
     },
     {
       "template_id": "api-regex-debug-trace-product-05",
       "regex": [
+        "(?i)trace",
         "(?i)exception",
-        "(?i)stack",
-        "(?i)trace"
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-product-06",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-product-07",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-product-08",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-product-09",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    {
+      "template_id": "api-regex-debug-trace-product-10",
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
       ]
     }
   ]

--- a/automations/regex_sets/session-ledger.json
+++ b/automations/regex_sets/session-ledger.json
@@ -6,801 +6,1601 @@
     {
       "template_id": "api-regex-session-ledger-access-management-01",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-access-management-02",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-access-management-03",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-access-management-04",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-access-management-05",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-access-management-06",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-access-management-07",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-access-management-08",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-access-management-09",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-access-management-10",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-accounting-01",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-accounting-02",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-accounting-03",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-accounting-04",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-accounting-05",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-accounting-06",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-accounting-07",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-accounting-08",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-accounting-09",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-accounting-10",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-analytics-01",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-analytics-02",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-analytics-03",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-analytics-04",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-analytics-05",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-analytics-06",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-analytics-07",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-analytics-08",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-analytics-09",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-analytics-10",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-audit-01",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-audit-02",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-audit-03",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-audit-04",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-audit-05",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-audit-06",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-audit-07",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-audit-08",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-audit-09",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-audit-10",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-billing-01",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-billing-02",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-billing-03",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-billing-04",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-billing-05",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-billing-06",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-billing-07",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-billing-08",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-billing-09",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-billing-10",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-business-intelligence-01",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-business-intelligence-02",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-business-intelligence-03",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-business-intelligence-04",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-business-intelligence-05",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-business-intelligence-06",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-business-intelligence-07",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-business-intelligence-08",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-business-intelligence-09",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-business-intelligence-10",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-cloud-ops-01",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-cloud-ops-02",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-cloud-ops-03",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-cloud-ops-04",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-cloud-ops-05",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-cloud-ops-06",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-cloud-ops-07",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-cloud-ops-08",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-cloud-ops-09",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-cloud-ops-10",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-collaboration-01",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-collaboration-02",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-collaboration-03",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-collaboration-04",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-collaboration-05",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-collaboration-06",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-collaboration-07",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-collaboration-08",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-collaboration-09",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-collaboration-10",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-commerce-01",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-commerce-02",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-commerce-03",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-commerce-04",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-commerce-05",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-commerce-06",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-commerce-07",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-commerce-08",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-commerce-09",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-commerce-10",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-compliance-01",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-compliance-02",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-compliance-03",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-compliance-04",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-compliance-05",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-compliance-06",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-compliance-07",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-compliance-08",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-compliance-09",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-compliance-10",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-customer-success-01",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-customer-success-02",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-customer-success-03",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-customer-success-04",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-customer-success-05",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-customer-success-06",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-customer-success-07",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-customer-success-08",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-customer-success-09",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-customer-success-10",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-devops-01",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-devops-02",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-devops-03",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-devops-04",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-devops-05",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-devops-06",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-devops-07",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-devops-08",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-devops-09",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-devops-10",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-finance-01",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-finance-02",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-finance-03",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-finance-04",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-finance-05",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-finance-06",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-finance-07",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-finance-08",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-finance-09",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-finance-10",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-governance-01",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-governance-02",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-governance-03",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-governance-04",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-governance-05",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-governance-06",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-governance-07",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-governance-08",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-governance-09",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-governance-10",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-identity-01",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-identity-02",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-identity-03",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-identity-04",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-identity-05",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-identity-06",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-identity-07",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-identity-08",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-identity-09",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-identity-10",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-infrastructure-01",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-infrastructure-02",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-infrastructure-03",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-infrastructure-04",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-infrastructure-05",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-infrastructure-06",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-infrastructure-07",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-infrastructure-08",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-infrastructure-09",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-infrastructure-10",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-logistics-01",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-logistics-02",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-logistics-03",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-logistics-04",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-logistics-05",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-logistics-06",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-logistics-07",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-logistics-08",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-logistics-09",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-logistics-10",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-marketing-01",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-marketing-02",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-marketing-03",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-marketing-04",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-marketing-05",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-marketing-06",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-marketing-07",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-marketing-08",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-marketing-09",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-marketing-10",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-operations-01",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-operations-02",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-operations-03",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-operations-04",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-operations-05",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-operations-06",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-operations-07",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-operations-08",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-operations-09",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-operations-10",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-product-01",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-product-02",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-product-03",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-product-04",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
       ]
     },
     {
       "template_id": "api-regex-session-ledger-product-05",
       "regex": [
-        "(?i)exp",
+        "(?i)session",
         "(?i)jwt",
-        "(?i)session"
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-product-06",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-product-07",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-product-08",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-product-09",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    {
+      "template_id": "api-regex-session-ledger-product-10",
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
       ]
     }
   ]

--- a/automations/regex_sets/telemetry-snapshot.json
+++ b/automations/regex_sets/telemetry-snapshot.json
@@ -6,800 +6,1600 @@
     {
       "template_id": "api-regex-telemetry-snapshot-access-management-01",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-access-management-02",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-access-management-03",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-access-management-04",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-access-management-05",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-access-management-06",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-access-management-07",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-access-management-08",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-access-management-09",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-access-management-10",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-accounting-01",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-accounting-02",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-accounting-03",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-accounting-04",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-accounting-05",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-accounting-06",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-accounting-07",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-accounting-08",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-accounting-09",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-accounting-10",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-analytics-01",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-analytics-02",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-analytics-03",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-analytics-04",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-analytics-05",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-analytics-06",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-analytics-07",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-analytics-08",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-analytics-09",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-analytics-10",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-audit-01",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-audit-02",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-audit-03",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-audit-04",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-audit-05",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-audit-06",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-audit-07",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-audit-08",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-audit-09",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-audit-10",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-billing-01",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-billing-02",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-billing-03",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-billing-04",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-billing-05",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-billing-06",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-billing-07",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-billing-08",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-billing-09",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-billing-10",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-business-intelligence-01",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-business-intelligence-02",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-business-intelligence-03",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-business-intelligence-04",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-business-intelligence-05",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-business-intelligence-06",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-business-intelligence-07",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-business-intelligence-08",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-business-intelligence-09",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-business-intelligence-10",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-cloud-ops-01",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-cloud-ops-02",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-cloud-ops-03",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-cloud-ops-04",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-cloud-ops-05",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-cloud-ops-06",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-cloud-ops-07",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-cloud-ops-08",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-cloud-ops-09",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-cloud-ops-10",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-collaboration-01",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-collaboration-02",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-collaboration-03",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-collaboration-04",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-collaboration-05",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-collaboration-06",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-collaboration-07",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-collaboration-08",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-collaboration-09",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-collaboration-10",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-commerce-01",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-commerce-02",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-commerce-03",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-commerce-04",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-commerce-05",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-commerce-06",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-commerce-07",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-commerce-08",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-commerce-09",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-commerce-10",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-compliance-01",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-compliance-02",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-compliance-03",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-compliance-04",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-compliance-05",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-compliance-06",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-compliance-07",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-compliance-08",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-compliance-09",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-compliance-10",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-customer-success-01",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-customer-success-02",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-customer-success-03",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-customer-success-04",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-customer-success-05",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-customer-success-06",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-customer-success-07",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-customer-success-08",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-customer-success-09",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-customer-success-10",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-devops-01",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-devops-02",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-devops-03",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-devops-04",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-devops-05",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-devops-06",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-devops-07",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-devops-08",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-devops-09",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-devops-10",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-finance-01",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-finance-02",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-finance-03",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-finance-04",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-finance-05",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-finance-06",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-finance-07",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-finance-08",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-finance-09",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-finance-10",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-governance-01",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-governance-02",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-governance-03",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-governance-04",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-governance-05",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-governance-06",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-governance-07",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-governance-08",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-governance-09",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-governance-10",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-identity-01",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-identity-02",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-identity-03",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-identity-04",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-identity-05",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-identity-06",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-identity-07",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-identity-08",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-identity-09",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-identity-10",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-infrastructure-01",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-infrastructure-02",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-infrastructure-03",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-infrastructure-04",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-infrastructure-05",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-infrastructure-06",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-infrastructure-07",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-infrastructure-08",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-infrastructure-09",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-infrastructure-10",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-logistics-01",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-logistics-02",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-logistics-03",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-logistics-04",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-logistics-05",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-logistics-06",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-logistics-07",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-logistics-08",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-logistics-09",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-logistics-10",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-marketing-01",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-marketing-02",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-marketing-03",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-marketing-04",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-marketing-05",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-marketing-06",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-marketing-07",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-marketing-08",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-marketing-09",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-marketing-10",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-operations-01",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-operations-02",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-operations-03",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-operations-04",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-operations-05",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-operations-06",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-operations-07",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-operations-08",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-operations-09",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-operations-10",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-product-01",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-product-02",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-product-03",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-product-04",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     },
     {
       "template_id": "api-regex-telemetry-snapshot-product-05",
       "regex": [
-        "(?i)metric",
         "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-product-06",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-product-07",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-product-08",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-product-09",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    {
+      "template_id": "api-regex-telemetry-snapshot-product-10",
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
         "(?i)timestamp"
       ]
     }

--- a/automations/regex_sets/token-cache.json
+++ b/automations/regex_sets/token-cache.json
@@ -6,801 +6,1601 @@
     {
       "template_id": "api-regex-token-cache-access-management-01",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-access-management-02",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-access-management-03",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-access-management-04",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-access-management-05",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-access-management-06",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-access-management-07",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-access-management-08",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-access-management-09",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-access-management-10",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-accounting-01",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-accounting-02",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-accounting-03",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-accounting-04",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-accounting-05",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-accounting-06",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-accounting-07",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-accounting-08",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-accounting-09",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-accounting-10",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-analytics-01",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-analytics-02",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-analytics-03",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-analytics-04",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-analytics-05",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-analytics-06",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-analytics-07",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-analytics-08",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-analytics-09",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-analytics-10",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-audit-01",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-audit-02",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-audit-03",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-audit-04",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-audit-05",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-audit-06",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-audit-07",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-audit-08",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-audit-09",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-audit-10",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-billing-01",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-billing-02",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-billing-03",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-billing-04",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-billing-05",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-billing-06",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-billing-07",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-billing-08",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-billing-09",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-billing-10",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-business-intelligence-01",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-business-intelligence-02",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-business-intelligence-03",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-business-intelligence-04",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-business-intelligence-05",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-business-intelligence-06",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-business-intelligence-07",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-business-intelligence-08",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-business-intelligence-09",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-business-intelligence-10",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-cloud-ops-01",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-cloud-ops-02",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-cloud-ops-03",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-cloud-ops-04",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-cloud-ops-05",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-cloud-ops-06",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-cloud-ops-07",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-cloud-ops-08",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-cloud-ops-09",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-cloud-ops-10",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-collaboration-01",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-collaboration-02",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-collaboration-03",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-collaboration-04",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-collaboration-05",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-collaboration-06",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-collaboration-07",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-collaboration-08",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-collaboration-09",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-collaboration-10",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-commerce-01",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-commerce-02",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-commerce-03",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-commerce-04",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-commerce-05",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-commerce-06",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-commerce-07",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-commerce-08",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-commerce-09",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-commerce-10",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-compliance-01",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-compliance-02",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-compliance-03",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-compliance-04",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-compliance-05",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-compliance-06",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-compliance-07",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-compliance-08",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-compliance-09",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-compliance-10",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-customer-success-01",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-customer-success-02",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-customer-success-03",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-customer-success-04",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-customer-success-05",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-customer-success-06",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-customer-success-07",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-customer-success-08",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-customer-success-09",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-customer-success-10",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-devops-01",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-devops-02",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-devops-03",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-devops-04",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-devops-05",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-devops-06",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-devops-07",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-devops-08",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-devops-09",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-devops-10",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-finance-01",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-finance-02",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-finance-03",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-finance-04",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-finance-05",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-finance-06",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-finance-07",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-finance-08",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-finance-09",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-finance-10",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-governance-01",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-governance-02",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-governance-03",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-governance-04",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-governance-05",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-governance-06",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-governance-07",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-governance-08",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-governance-09",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-governance-10",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-identity-01",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-identity-02",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-identity-03",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-identity-04",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-identity-05",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-identity-06",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-identity-07",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-identity-08",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-identity-09",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-identity-10",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-infrastructure-01",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-infrastructure-02",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-infrastructure-03",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-infrastructure-04",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-infrastructure-05",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-infrastructure-06",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-infrastructure-07",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-infrastructure-08",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-infrastructure-09",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-infrastructure-10",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-logistics-01",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-logistics-02",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-logistics-03",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-logistics-04",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-logistics-05",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-logistics-06",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-logistics-07",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-logistics-08",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-logistics-09",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-logistics-10",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-marketing-01",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-marketing-02",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-marketing-03",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-marketing-04",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-marketing-05",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-marketing-06",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-marketing-07",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-marketing-08",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-marketing-09",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-marketing-10",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-operations-01",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-operations-02",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-operations-03",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-operations-04",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-operations-05",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-operations-06",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-operations-07",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-operations-08",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-operations-09",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-operations-10",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-product-01",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-product-02",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-product-03",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-product-04",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
       ]
     },
     {
       "template_id": "api-regex-token-cache-product-05",
       "regex": [
-        "(?i)bearer",
+        "(?i)token",
         "(?i)secret",
-        "(?i)token"
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-product-06",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-product-07",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-product-08",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-product-09",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    {
+      "template_id": "api-regex-token-cache-product-10",
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
       ]
     }
   ]

--- a/automations/regex_sets/user-dump.json
+++ b/automations/regex_sets/user-dump.json
@@ -7,800 +7,1600 @@
       "template_id": "api-regex-user-dump-access-management-01",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-access-management-02",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-access-management-03",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-access-management-04",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-access-management-05",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-access-management-06",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-access-management-07",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-access-management-08",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-access-management-09",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-access-management-10",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-accounting-01",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-accounting-02",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-accounting-03",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-accounting-04",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-accounting-05",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-accounting-06",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-accounting-07",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-accounting-08",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-accounting-09",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-accounting-10",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-analytics-01",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-analytics-02",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-analytics-03",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-analytics-04",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-analytics-05",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-analytics-06",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-analytics-07",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-analytics-08",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-analytics-09",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-analytics-10",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-audit-01",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-audit-02",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-audit-03",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-audit-04",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-audit-05",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-audit-06",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-audit-07",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-audit-08",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-audit-09",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-audit-10",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-billing-01",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-billing-02",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-billing-03",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-billing-04",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-billing-05",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-billing-06",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-billing-07",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-billing-08",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-billing-09",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-billing-10",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-business-intelligence-01",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-business-intelligence-02",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-business-intelligence-03",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-business-intelligence-04",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-business-intelligence-05",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-business-intelligence-06",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-business-intelligence-07",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-business-intelligence-08",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-business-intelligence-09",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-business-intelligence-10",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-cloud-ops-01",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-cloud-ops-02",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-cloud-ops-03",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-cloud-ops-04",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-cloud-ops-05",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-cloud-ops-06",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-cloud-ops-07",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-cloud-ops-08",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-cloud-ops-09",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-cloud-ops-10",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-collaboration-01",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-collaboration-02",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-collaboration-03",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-collaboration-04",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-collaboration-05",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-collaboration-06",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-collaboration-07",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-collaboration-08",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-collaboration-09",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-collaboration-10",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-commerce-01",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-commerce-02",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-commerce-03",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-commerce-04",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-commerce-05",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-commerce-06",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-commerce-07",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-commerce-08",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-commerce-09",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-commerce-10",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-compliance-01",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-compliance-02",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-compliance-03",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-compliance-04",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-compliance-05",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-compliance-06",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-compliance-07",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-compliance-08",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-compliance-09",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-compliance-10",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-customer-success-01",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-customer-success-02",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-customer-success-03",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-customer-success-04",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-customer-success-05",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-customer-success-06",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-customer-success-07",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-customer-success-08",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-customer-success-09",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-customer-success-10",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-devops-01",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-devops-02",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-devops-03",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-devops-04",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-devops-05",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-devops-06",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-devops-07",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-devops-08",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-devops-09",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-devops-10",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-finance-01",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-finance-02",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-finance-03",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-finance-04",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-finance-05",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-finance-06",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-finance-07",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-finance-08",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-finance-09",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-finance-10",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-governance-01",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-governance-02",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-governance-03",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-governance-04",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-governance-05",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-governance-06",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-governance-07",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-governance-08",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-governance-09",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-governance-10",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-identity-01",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-identity-02",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-identity-03",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-identity-04",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-identity-05",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-identity-06",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-identity-07",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-identity-08",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-identity-09",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-identity-10",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-infrastructure-01",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-infrastructure-02",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-infrastructure-03",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-infrastructure-04",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-infrastructure-05",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-infrastructure-06",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-infrastructure-07",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-infrastructure-08",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-infrastructure-09",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-infrastructure-10",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-logistics-01",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-logistics-02",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-logistics-03",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-logistics-04",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-logistics-05",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-logistics-06",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-logistics-07",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-logistics-08",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-logistics-09",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-logistics-10",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-marketing-01",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-marketing-02",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-marketing-03",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-marketing-04",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-marketing-05",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-marketing-06",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-marketing-07",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-marketing-08",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-marketing-09",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-marketing-10",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-operations-01",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-operations-02",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-operations-03",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-operations-04",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-operations-05",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-operations-06",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-operations-07",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-operations-08",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-operations-09",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-operations-10",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-product-01",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-product-02",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-product-03",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-product-04",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
       ]
     },
     {
       "template_id": "api-regex-user-dump-product-05",
       "regex": [
         "(?i)email",
-        "(?i)id",
-        "(?i)user"
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-product-06",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-product-07",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-product-08",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-product-09",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    {
+      "template_id": "api-regex-user-dump-product-10",
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
       ]
     }
   ]

--- a/automations/regex_sets/webhook-registry.json
+++ b/automations/regex_sets/webhook-registry.json
@@ -6,801 +6,1601 @@
     {
       "template_id": "api-regex-webhook-registry-access-management-01",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-access-management-02",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-access-management-03",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-access-management-04",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-access-management-05",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-access-management-06",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-access-management-07",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-access-management-08",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-access-management-09",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-access-management-10",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-accounting-01",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-accounting-02",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-accounting-03",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-accounting-04",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-accounting-05",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-accounting-06",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-accounting-07",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-accounting-08",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-accounting-09",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-accounting-10",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-analytics-01",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-analytics-02",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-analytics-03",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-analytics-04",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-analytics-05",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-analytics-06",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-analytics-07",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-analytics-08",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-analytics-09",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-analytics-10",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-audit-01",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-audit-02",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-audit-03",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-audit-04",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-audit-05",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-audit-06",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-audit-07",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-audit-08",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-audit-09",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-audit-10",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-billing-01",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-billing-02",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-billing-03",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-billing-04",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-billing-05",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-billing-06",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-billing-07",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-billing-08",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-billing-09",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-billing-10",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-business-intelligence-01",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-business-intelligence-02",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-business-intelligence-03",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-business-intelligence-04",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-business-intelligence-05",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-business-intelligence-06",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-business-intelligence-07",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-business-intelligence-08",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-business-intelligence-09",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-business-intelligence-10",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-cloud-ops-01",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-cloud-ops-02",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-cloud-ops-03",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-cloud-ops-04",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-cloud-ops-05",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-cloud-ops-06",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-cloud-ops-07",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-cloud-ops-08",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-cloud-ops-09",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-cloud-ops-10",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-collaboration-01",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-collaboration-02",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-collaboration-03",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-collaboration-04",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-collaboration-05",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-collaboration-06",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-collaboration-07",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-collaboration-08",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-collaboration-09",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-collaboration-10",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-commerce-01",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-commerce-02",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-commerce-03",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-commerce-04",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-commerce-05",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-commerce-06",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-commerce-07",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-commerce-08",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-commerce-09",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-commerce-10",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-compliance-01",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-compliance-02",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-compliance-03",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-compliance-04",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-compliance-05",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-compliance-06",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-compliance-07",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-compliance-08",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-compliance-09",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-compliance-10",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-customer-success-01",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-customer-success-02",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-customer-success-03",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-customer-success-04",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-customer-success-05",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-customer-success-06",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-customer-success-07",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-customer-success-08",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-customer-success-09",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-customer-success-10",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-devops-01",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-devops-02",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-devops-03",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-devops-04",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-devops-05",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-devops-06",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-devops-07",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-devops-08",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-devops-09",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-devops-10",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-finance-01",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-finance-02",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-finance-03",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-finance-04",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-finance-05",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-finance-06",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-finance-07",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-finance-08",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-finance-09",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-finance-10",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-governance-01",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-governance-02",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-governance-03",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-governance-04",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-governance-05",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-governance-06",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-governance-07",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-governance-08",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-governance-09",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-governance-10",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-identity-01",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-identity-02",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-identity-03",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-identity-04",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-identity-05",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-identity-06",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-identity-07",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-identity-08",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-identity-09",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-identity-10",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-infrastructure-01",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-infrastructure-02",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-infrastructure-03",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-infrastructure-04",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-infrastructure-05",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-infrastructure-06",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-infrastructure-07",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-infrastructure-08",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-infrastructure-09",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-infrastructure-10",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-logistics-01",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-logistics-02",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-logistics-03",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-logistics-04",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-logistics-05",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-logistics-06",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-logistics-07",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-logistics-08",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-logistics-09",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-logistics-10",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-marketing-01",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-marketing-02",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-marketing-03",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-marketing-04",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-marketing-05",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-marketing-06",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-marketing-07",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-marketing-08",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-marketing-09",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-marketing-10",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-operations-01",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-operations-02",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-operations-03",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-operations-04",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-operations-05",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-operations-06",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-operations-07",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-operations-08",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-operations-09",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-operations-10",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-product-01",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-product-02",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-product-03",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-product-04",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
       ]
     },
     {
       "template_id": "api-regex-webhook-registry-product-05",
       "regex": [
+        "(?i)webhook",
         "(?i)callback",
-        "(?i)signature",
-        "(?i)webhook"
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-product-06",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-product-07",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-product-08",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-product-09",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    {
+      "template_id": "api-regex-webhook-registry-product-10",
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
       ]
     }
   ]

--- a/automations/templates.json
+++ b/automations/templates.json
@@ -44123,5 +44123,23005 @@
       "compliance",
       "product"
     ]
+  },
+  {
+    "id": "api-regex-token-cache-access-management-06",
+    "name": "Access Management Token Cache Dump #6",
+    "description": "Detects exposed Access Management token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/token-cache-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-access-management-07",
+    "name": "Access Management Token Cache Dump #7",
+    "description": "Detects exposed Access Management token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/token-cache-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-access-management-08",
+    "name": "Access Management Token Cache Dump #8",
+    "description": "Detects exposed Access Management token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/token-cache-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-access-management-09",
+    "name": "Access Management Token Cache Dump #9",
+    "description": "Detects exposed Access Management token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/token-cache-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-access-management-10",
+    "name": "Access Management Token Cache Dump #10",
+    "description": "Detects exposed Access Management token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/token-cache-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-access-management-06",
+    "name": "Access Management Session Ledger Leak #6",
+    "description": "Catches leaked Access Management session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/sessions-ledger-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-access-management-07",
+    "name": "Access Management Session Ledger Leak #7",
+    "description": "Catches leaked Access Management session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/sessions-ledger-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-access-management-08",
+    "name": "Access Management Session Ledger Leak #8",
+    "description": "Catches leaked Access Management session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/sessions-ledger-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-access-management-09",
+    "name": "Access Management Session Ledger Leak #9",
+    "description": "Catches leaked Access Management session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/sessions-ledger-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-access-management-10",
+    "name": "Access Management Session Ledger Leak #10",
+    "description": "Catches leaked Access Management session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/sessions-ledger-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-access-management-06",
+    "name": "Access Management Config Export Exposure #6",
+    "description": "Finds world-readable Access Management configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/config-export-06.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-access-management-07",
+    "name": "Access Management Config Export Exposure #7",
+    "description": "Finds world-readable Access Management configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/config-export-07.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-access-management-08",
+    "name": "Access Management Config Export Exposure #8",
+    "description": "Finds world-readable Access Management configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/config-export-08.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-access-management-09",
+    "name": "Access Management Config Export Exposure #9",
+    "description": "Finds world-readable Access Management configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/config-export-09.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-access-management-10",
+    "name": "Access Management Config Export Exposure #10",
+    "description": "Finds world-readable Access Management configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/config-export-10.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-access-management-06",
+    "name": "Access Management User Dump Exposure #6",
+    "description": "Detects exposed Access Management user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/user-dump-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-access-management-07",
+    "name": "Access Management User Dump Exposure #7",
+    "description": "Detects exposed Access Management user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/access-management/user-dump-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-access-management-08",
+    "name": "Access Management User Dump Exposure #8",
+    "description": "Detects exposed Access Management user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/user-dump-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-access-management-09",
+    "name": "Access Management User Dump Exposure #9",
+    "description": "Detects exposed Access Management user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/user-dump-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-access-management-10",
+    "name": "Access Management User Dump Exposure #10",
+    "description": "Detects exposed Access Management user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/user-dump-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-access-management-06",
+    "name": "Access Management Billing Export Exposure #6",
+    "description": "Identifies Access Management billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/billing-export-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-access-management-07",
+    "name": "Access Management Billing Export Exposure #7",
+    "description": "Identifies Access Management billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/access-management/billing-export-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-access-management-08",
+    "name": "Access Management Billing Export Exposure #8",
+    "description": "Identifies Access Management billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/billing-export-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-access-management-09",
+    "name": "Access Management Billing Export Exposure #9",
+    "description": "Identifies Access Management billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/billing-export-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-access-management-10",
+    "name": "Access Management Billing Export Exposure #10",
+    "description": "Identifies Access Management billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/billing-export-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-access-management-06",
+    "name": "Access Management Webhook Registry Leak #6",
+    "description": "Detects leaked Access Management webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/webhooks-registry-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-access-management-07",
+    "name": "Access Management Webhook Registry Leak #7",
+    "description": "Detects leaked Access Management webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/webhooks-registry-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-access-management-08",
+    "name": "Access Management Webhook Registry Leak #8",
+    "description": "Detects leaked Access Management webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/webhooks-registry-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-access-management-09",
+    "name": "Access Management Webhook Registry Leak #9",
+    "description": "Detects leaked Access Management webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/webhooks-registry-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-access-management-10",
+    "name": "Access Management Webhook Registry Leak #10",
+    "description": "Detects leaked Access Management webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/webhooks-registry-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-access-management-06",
+    "name": "Access Management Telemetry Snapshot Exposure #6",
+    "description": "Surfaces exposed Access Management telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/telemetry-snapshot-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-access-management-07",
+    "name": "Access Management Telemetry Snapshot Exposure #7",
+    "description": "Surfaces exposed Access Management telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/access-management/telemetry-snapshot-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-access-management-08",
+    "name": "Access Management Telemetry Snapshot Exposure #8",
+    "description": "Surfaces exposed Access Management telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/telemetry-snapshot-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-access-management-09",
+    "name": "Access Management Telemetry Snapshot Exposure #9",
+    "description": "Surfaces exposed Access Management telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/telemetry-snapshot-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-access-management-10",
+    "name": "Access Management Telemetry Snapshot Exposure #10",
+    "description": "Surfaces exposed Access Management telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/telemetry-snapshot-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-access-management-06",
+    "name": "Access Management Debug Trace Log Leak #6",
+    "description": "Detects leaked Access Management debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/debug-trace-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-access-management-07",
+    "name": "Access Management Debug Trace Log Leak #7",
+    "description": "Detects leaked Access Management debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/access-management/debug-trace-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-access-management-08",
+    "name": "Access Management Debug Trace Log Leak #8",
+    "description": "Detects leaked Access Management debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/debug-trace-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-access-management-09",
+    "name": "Access Management Debug Trace Log Leak #9",
+    "description": "Detects leaked Access Management debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/debug-trace-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-access-management-10",
+    "name": "Access Management Debug Trace Log Leak #10",
+    "description": "Detects leaked Access Management debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/debug-trace-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-access-management-06",
+    "name": "Access Management Database Backup Exposure #6",
+    "description": "Finds exposed Access Management database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/db-backup-06.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-access-management-07",
+    "name": "Access Management Database Backup Exposure #7",
+    "description": "Finds exposed Access Management database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/db-backup-07.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-access-management-08",
+    "name": "Access Management Database Backup Exposure #8",
+    "description": "Finds exposed Access Management database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/db-backup-08.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-access-management-09",
+    "name": "Access Management Database Backup Exposure #9",
+    "description": "Finds exposed Access Management database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/db-backup-09.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-access-management-10",
+    "name": "Access Management Database Backup Exposure #10",
+    "description": "Finds exposed Access Management database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/access-management/db-backup-10.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-access-management-06",
+    "name": "Access Management Compliance Report Leak #6",
+    "description": "Detects leaked Access Management compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/compliance-report-06.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-access-management-07",
+    "name": "Access Management Compliance Report Leak #7",
+    "description": "Detects leaked Access Management compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/access-management/compliance-report-07.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-access-management-08",
+    "name": "Access Management Compliance Report Leak #8",
+    "description": "Detects leaked Access Management compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/compliance-report-08.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-access-management-09",
+    "name": "Access Management Compliance Report Leak #9",
+    "description": "Detects leaked Access Management compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/compliance-report-09.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-access-management-10",
+    "name": "Access Management Compliance Report Leak #10",
+    "description": "Detects leaked Access Management compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/access-management/compliance-report-10.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "access-management"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-accounting-06",
+    "name": "Accounting Token Cache Dump #6",
+    "description": "Detects exposed Accounting token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/token-cache-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-accounting-07",
+    "name": "Accounting Token Cache Dump #7",
+    "description": "Detects exposed Accounting token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/token-cache-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-accounting-08",
+    "name": "Accounting Token Cache Dump #8",
+    "description": "Detects exposed Accounting token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/token-cache-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-accounting-09",
+    "name": "Accounting Token Cache Dump #9",
+    "description": "Detects exposed Accounting token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/token-cache-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-accounting-10",
+    "name": "Accounting Token Cache Dump #10",
+    "description": "Detects exposed Accounting token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/token-cache-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-accounting-06",
+    "name": "Accounting Session Ledger Leak #6",
+    "description": "Catches leaked Accounting session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/sessions-ledger-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-accounting-07",
+    "name": "Accounting Session Ledger Leak #7",
+    "description": "Catches leaked Accounting session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/sessions-ledger-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-accounting-08",
+    "name": "Accounting Session Ledger Leak #8",
+    "description": "Catches leaked Accounting session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/sessions-ledger-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-accounting-09",
+    "name": "Accounting Session Ledger Leak #9",
+    "description": "Catches leaked Accounting session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/sessions-ledger-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-accounting-10",
+    "name": "Accounting Session Ledger Leak #10",
+    "description": "Catches leaked Accounting session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/sessions-ledger-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-accounting-06",
+    "name": "Accounting Config Export Exposure #6",
+    "description": "Finds world-readable Accounting configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/config-export-06.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-accounting-07",
+    "name": "Accounting Config Export Exposure #7",
+    "description": "Finds world-readable Accounting configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/config-export-07.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-accounting-08",
+    "name": "Accounting Config Export Exposure #8",
+    "description": "Finds world-readable Accounting configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/config-export-08.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-accounting-09",
+    "name": "Accounting Config Export Exposure #9",
+    "description": "Finds world-readable Accounting configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/config-export-09.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-accounting-10",
+    "name": "Accounting Config Export Exposure #10",
+    "description": "Finds world-readable Accounting configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/config-export-10.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-accounting-06",
+    "name": "Accounting User Dump Exposure #6",
+    "description": "Detects exposed Accounting user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/user-dump-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-accounting-07",
+    "name": "Accounting User Dump Exposure #7",
+    "description": "Detects exposed Accounting user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/accounting/user-dump-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-accounting-08",
+    "name": "Accounting User Dump Exposure #8",
+    "description": "Detects exposed Accounting user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/user-dump-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-accounting-09",
+    "name": "Accounting User Dump Exposure #9",
+    "description": "Detects exposed Accounting user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/user-dump-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-accounting-10",
+    "name": "Accounting User Dump Exposure #10",
+    "description": "Detects exposed Accounting user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/user-dump-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-accounting-06",
+    "name": "Accounting Billing Export Exposure #6",
+    "description": "Identifies Accounting billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/billing-export-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-accounting-07",
+    "name": "Accounting Billing Export Exposure #7",
+    "description": "Identifies Accounting billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/accounting/billing-export-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-accounting-08",
+    "name": "Accounting Billing Export Exposure #8",
+    "description": "Identifies Accounting billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/billing-export-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-accounting-09",
+    "name": "Accounting Billing Export Exposure #9",
+    "description": "Identifies Accounting billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/billing-export-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-accounting-10",
+    "name": "Accounting Billing Export Exposure #10",
+    "description": "Identifies Accounting billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/billing-export-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-accounting-06",
+    "name": "Accounting Webhook Registry Leak #6",
+    "description": "Detects leaked Accounting webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/webhooks-registry-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-accounting-07",
+    "name": "Accounting Webhook Registry Leak #7",
+    "description": "Detects leaked Accounting webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/webhooks-registry-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-accounting-08",
+    "name": "Accounting Webhook Registry Leak #8",
+    "description": "Detects leaked Accounting webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/webhooks-registry-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-accounting-09",
+    "name": "Accounting Webhook Registry Leak #9",
+    "description": "Detects leaked Accounting webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/webhooks-registry-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-accounting-10",
+    "name": "Accounting Webhook Registry Leak #10",
+    "description": "Detects leaked Accounting webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/webhooks-registry-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-accounting-06",
+    "name": "Accounting Telemetry Snapshot Exposure #6",
+    "description": "Surfaces exposed Accounting telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/telemetry-snapshot-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-accounting-07",
+    "name": "Accounting Telemetry Snapshot Exposure #7",
+    "description": "Surfaces exposed Accounting telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/accounting/telemetry-snapshot-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-accounting-08",
+    "name": "Accounting Telemetry Snapshot Exposure #8",
+    "description": "Surfaces exposed Accounting telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/telemetry-snapshot-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-accounting-09",
+    "name": "Accounting Telemetry Snapshot Exposure #9",
+    "description": "Surfaces exposed Accounting telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/telemetry-snapshot-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-accounting-10",
+    "name": "Accounting Telemetry Snapshot Exposure #10",
+    "description": "Surfaces exposed Accounting telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/telemetry-snapshot-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-accounting-06",
+    "name": "Accounting Debug Trace Log Leak #6",
+    "description": "Detects leaked Accounting debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/debug-trace-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-accounting-07",
+    "name": "Accounting Debug Trace Log Leak #7",
+    "description": "Detects leaked Accounting debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/accounting/debug-trace-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-accounting-08",
+    "name": "Accounting Debug Trace Log Leak #8",
+    "description": "Detects leaked Accounting debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/debug-trace-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-accounting-09",
+    "name": "Accounting Debug Trace Log Leak #9",
+    "description": "Detects leaked Accounting debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/debug-trace-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-accounting-10",
+    "name": "Accounting Debug Trace Log Leak #10",
+    "description": "Detects leaked Accounting debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/debug-trace-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-accounting-06",
+    "name": "Accounting Database Backup Exposure #6",
+    "description": "Finds exposed Accounting database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/db-backup-06.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-accounting-07",
+    "name": "Accounting Database Backup Exposure #7",
+    "description": "Finds exposed Accounting database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/db-backup-07.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-accounting-08",
+    "name": "Accounting Database Backup Exposure #8",
+    "description": "Finds exposed Accounting database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/db-backup-08.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-accounting-09",
+    "name": "Accounting Database Backup Exposure #9",
+    "description": "Finds exposed Accounting database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/db-backup-09.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-accounting-10",
+    "name": "Accounting Database Backup Exposure #10",
+    "description": "Finds exposed Accounting database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/accounting/db-backup-10.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-accounting-06",
+    "name": "Accounting Compliance Report Leak #6",
+    "description": "Detects leaked Accounting compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/compliance-report-06.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-accounting-07",
+    "name": "Accounting Compliance Report Leak #7",
+    "description": "Detects leaked Accounting compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/accounting/compliance-report-07.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-accounting-08",
+    "name": "Accounting Compliance Report Leak #8",
+    "description": "Detects leaked Accounting compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/compliance-report-08.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-accounting-09",
+    "name": "Accounting Compliance Report Leak #9",
+    "description": "Detects leaked Accounting compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/compliance-report-09.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-accounting-10",
+    "name": "Accounting Compliance Report Leak #10",
+    "description": "Detects leaked Accounting compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/accounting/compliance-report-10.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "accounting"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-analytics-06",
+    "name": "Analytics Token Cache Dump #6",
+    "description": "Detects exposed Analytics token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/token-cache-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-analytics-07",
+    "name": "Analytics Token Cache Dump #7",
+    "description": "Detects exposed Analytics token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/token-cache-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-analytics-08",
+    "name": "Analytics Token Cache Dump #8",
+    "description": "Detects exposed Analytics token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/token-cache-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-analytics-09",
+    "name": "Analytics Token Cache Dump #9",
+    "description": "Detects exposed Analytics token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/token-cache-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-analytics-10",
+    "name": "Analytics Token Cache Dump #10",
+    "description": "Detects exposed Analytics token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/token-cache-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-analytics-06",
+    "name": "Analytics Session Ledger Leak #6",
+    "description": "Catches leaked Analytics session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/sessions-ledger-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-analytics-07",
+    "name": "Analytics Session Ledger Leak #7",
+    "description": "Catches leaked Analytics session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/sessions-ledger-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-analytics-08",
+    "name": "Analytics Session Ledger Leak #8",
+    "description": "Catches leaked Analytics session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/sessions-ledger-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-analytics-09",
+    "name": "Analytics Session Ledger Leak #9",
+    "description": "Catches leaked Analytics session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/sessions-ledger-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-analytics-10",
+    "name": "Analytics Session Ledger Leak #10",
+    "description": "Catches leaked Analytics session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/sessions-ledger-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-analytics-06",
+    "name": "Analytics Config Export Exposure #6",
+    "description": "Finds world-readable Analytics configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/config-export-06.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-analytics-07",
+    "name": "Analytics Config Export Exposure #7",
+    "description": "Finds world-readable Analytics configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/config-export-07.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-analytics-08",
+    "name": "Analytics Config Export Exposure #8",
+    "description": "Finds world-readable Analytics configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/config-export-08.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-analytics-09",
+    "name": "Analytics Config Export Exposure #9",
+    "description": "Finds world-readable Analytics configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/config-export-09.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-analytics-10",
+    "name": "Analytics Config Export Exposure #10",
+    "description": "Finds world-readable Analytics configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/config-export-10.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-analytics-06",
+    "name": "Analytics User Dump Exposure #6",
+    "description": "Detects exposed Analytics user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/user-dump-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-analytics-07",
+    "name": "Analytics User Dump Exposure #7",
+    "description": "Detects exposed Analytics user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/analytics/user-dump-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-analytics-08",
+    "name": "Analytics User Dump Exposure #8",
+    "description": "Detects exposed Analytics user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/user-dump-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-analytics-09",
+    "name": "Analytics User Dump Exposure #9",
+    "description": "Detects exposed Analytics user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/user-dump-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-analytics-10",
+    "name": "Analytics User Dump Exposure #10",
+    "description": "Detects exposed Analytics user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/user-dump-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-analytics-06",
+    "name": "Analytics Billing Export Exposure #6",
+    "description": "Identifies Analytics billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/billing-export-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-analytics-07",
+    "name": "Analytics Billing Export Exposure #7",
+    "description": "Identifies Analytics billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/analytics/billing-export-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-analytics-08",
+    "name": "Analytics Billing Export Exposure #8",
+    "description": "Identifies Analytics billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/billing-export-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-analytics-09",
+    "name": "Analytics Billing Export Exposure #9",
+    "description": "Identifies Analytics billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/billing-export-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-analytics-10",
+    "name": "Analytics Billing Export Exposure #10",
+    "description": "Identifies Analytics billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/billing-export-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-analytics-06",
+    "name": "Analytics Webhook Registry Leak #6",
+    "description": "Detects leaked Analytics webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/webhooks-registry-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-analytics-07",
+    "name": "Analytics Webhook Registry Leak #7",
+    "description": "Detects leaked Analytics webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/webhooks-registry-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-analytics-08",
+    "name": "Analytics Webhook Registry Leak #8",
+    "description": "Detects leaked Analytics webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/webhooks-registry-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-analytics-09",
+    "name": "Analytics Webhook Registry Leak #9",
+    "description": "Detects leaked Analytics webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/webhooks-registry-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-analytics-10",
+    "name": "Analytics Webhook Registry Leak #10",
+    "description": "Detects leaked Analytics webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/webhooks-registry-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-analytics-06",
+    "name": "Analytics Telemetry Snapshot Exposure #6",
+    "description": "Surfaces exposed Analytics telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/telemetry-snapshot-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-analytics-07",
+    "name": "Analytics Telemetry Snapshot Exposure #7",
+    "description": "Surfaces exposed Analytics telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/analytics/telemetry-snapshot-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-analytics-08",
+    "name": "Analytics Telemetry Snapshot Exposure #8",
+    "description": "Surfaces exposed Analytics telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/telemetry-snapshot-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-analytics-09",
+    "name": "Analytics Telemetry Snapshot Exposure #9",
+    "description": "Surfaces exposed Analytics telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/telemetry-snapshot-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-analytics-10",
+    "name": "Analytics Telemetry Snapshot Exposure #10",
+    "description": "Surfaces exposed Analytics telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/telemetry-snapshot-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-analytics-06",
+    "name": "Analytics Debug Trace Log Leak #6",
+    "description": "Detects leaked Analytics debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/debug-trace-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-analytics-07",
+    "name": "Analytics Debug Trace Log Leak #7",
+    "description": "Detects leaked Analytics debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/analytics/debug-trace-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-analytics-08",
+    "name": "Analytics Debug Trace Log Leak #8",
+    "description": "Detects leaked Analytics debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/debug-trace-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-analytics-09",
+    "name": "Analytics Debug Trace Log Leak #9",
+    "description": "Detects leaked Analytics debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/debug-trace-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-analytics-10",
+    "name": "Analytics Debug Trace Log Leak #10",
+    "description": "Detects leaked Analytics debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/debug-trace-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-analytics-06",
+    "name": "Analytics Database Backup Exposure #6",
+    "description": "Finds exposed Analytics database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/db-backup-06.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-analytics-07",
+    "name": "Analytics Database Backup Exposure #7",
+    "description": "Finds exposed Analytics database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/db-backup-07.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-analytics-08",
+    "name": "Analytics Database Backup Exposure #8",
+    "description": "Finds exposed Analytics database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/db-backup-08.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-analytics-09",
+    "name": "Analytics Database Backup Exposure #9",
+    "description": "Finds exposed Analytics database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/db-backup-09.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-analytics-10",
+    "name": "Analytics Database Backup Exposure #10",
+    "description": "Finds exposed Analytics database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/analytics/db-backup-10.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-analytics-06",
+    "name": "Analytics Compliance Report Leak #6",
+    "description": "Detects leaked Analytics compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/compliance-report-06.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-analytics-07",
+    "name": "Analytics Compliance Report Leak #7",
+    "description": "Detects leaked Analytics compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/analytics/compliance-report-07.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-analytics-08",
+    "name": "Analytics Compliance Report Leak #8",
+    "description": "Detects leaked Analytics compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/compliance-report-08.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-analytics-09",
+    "name": "Analytics Compliance Report Leak #9",
+    "description": "Detects leaked Analytics compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/compliance-report-09.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-analytics-10",
+    "name": "Analytics Compliance Report Leak #10",
+    "description": "Detects leaked Analytics compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/analytics/compliance-report-10.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "analytics"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-audit-06",
+    "name": "Audit Token Cache Dump #6",
+    "description": "Detects exposed Audit token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/token-cache-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-audit-07",
+    "name": "Audit Token Cache Dump #7",
+    "description": "Detects exposed Audit token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/token-cache-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-audit-08",
+    "name": "Audit Token Cache Dump #8",
+    "description": "Detects exposed Audit token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/token-cache-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-audit-09",
+    "name": "Audit Token Cache Dump #9",
+    "description": "Detects exposed Audit token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/token-cache-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-audit-10",
+    "name": "Audit Token Cache Dump #10",
+    "description": "Detects exposed Audit token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/token-cache-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-audit-06",
+    "name": "Audit Session Ledger Leak #6",
+    "description": "Catches leaked Audit session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/sessions-ledger-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-audit-07",
+    "name": "Audit Session Ledger Leak #7",
+    "description": "Catches leaked Audit session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/sessions-ledger-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-audit-08",
+    "name": "Audit Session Ledger Leak #8",
+    "description": "Catches leaked Audit session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/sessions-ledger-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-audit-09",
+    "name": "Audit Session Ledger Leak #9",
+    "description": "Catches leaked Audit session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/sessions-ledger-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-audit-10",
+    "name": "Audit Session Ledger Leak #10",
+    "description": "Catches leaked Audit session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/sessions-ledger-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-audit-06",
+    "name": "Audit Config Export Exposure #6",
+    "description": "Finds world-readable Audit configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/config-export-06.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-audit-07",
+    "name": "Audit Config Export Exposure #7",
+    "description": "Finds world-readable Audit configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/config-export-07.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-audit-08",
+    "name": "Audit Config Export Exposure #8",
+    "description": "Finds world-readable Audit configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/config-export-08.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-audit-09",
+    "name": "Audit Config Export Exposure #9",
+    "description": "Finds world-readable Audit configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/config-export-09.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-audit-10",
+    "name": "Audit Config Export Exposure #10",
+    "description": "Finds world-readable Audit configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/config-export-10.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-audit-06",
+    "name": "Audit User Dump Exposure #6",
+    "description": "Detects exposed Audit user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/user-dump-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-audit-07",
+    "name": "Audit User Dump Exposure #7",
+    "description": "Detects exposed Audit user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/audit/user-dump-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-audit-08",
+    "name": "Audit User Dump Exposure #8",
+    "description": "Detects exposed Audit user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/user-dump-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-audit-09",
+    "name": "Audit User Dump Exposure #9",
+    "description": "Detects exposed Audit user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/user-dump-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-audit-10",
+    "name": "Audit User Dump Exposure #10",
+    "description": "Detects exposed Audit user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/user-dump-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-audit-06",
+    "name": "Audit Billing Export Exposure #6",
+    "description": "Identifies Audit billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/billing-export-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-audit-07",
+    "name": "Audit Billing Export Exposure #7",
+    "description": "Identifies Audit billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/audit/billing-export-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-audit-08",
+    "name": "Audit Billing Export Exposure #8",
+    "description": "Identifies Audit billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/billing-export-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-audit-09",
+    "name": "Audit Billing Export Exposure #9",
+    "description": "Identifies Audit billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/billing-export-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-audit-10",
+    "name": "Audit Billing Export Exposure #10",
+    "description": "Identifies Audit billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/billing-export-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-audit-06",
+    "name": "Audit Webhook Registry Leak #6",
+    "description": "Detects leaked Audit webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/webhooks-registry-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-audit-07",
+    "name": "Audit Webhook Registry Leak #7",
+    "description": "Detects leaked Audit webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/webhooks-registry-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-audit-08",
+    "name": "Audit Webhook Registry Leak #8",
+    "description": "Detects leaked Audit webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/webhooks-registry-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-audit-09",
+    "name": "Audit Webhook Registry Leak #9",
+    "description": "Detects leaked Audit webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/webhooks-registry-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-audit-10",
+    "name": "Audit Webhook Registry Leak #10",
+    "description": "Detects leaked Audit webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/webhooks-registry-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-audit-06",
+    "name": "Audit Telemetry Snapshot Exposure #6",
+    "description": "Surfaces exposed Audit telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/telemetry-snapshot-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-audit-07",
+    "name": "Audit Telemetry Snapshot Exposure #7",
+    "description": "Surfaces exposed Audit telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/audit/telemetry-snapshot-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-audit-08",
+    "name": "Audit Telemetry Snapshot Exposure #8",
+    "description": "Surfaces exposed Audit telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/telemetry-snapshot-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-audit-09",
+    "name": "Audit Telemetry Snapshot Exposure #9",
+    "description": "Surfaces exposed Audit telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/telemetry-snapshot-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-audit-10",
+    "name": "Audit Telemetry Snapshot Exposure #10",
+    "description": "Surfaces exposed Audit telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/telemetry-snapshot-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-audit-06",
+    "name": "Audit Debug Trace Log Leak #6",
+    "description": "Detects leaked Audit debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/debug-trace-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-audit-07",
+    "name": "Audit Debug Trace Log Leak #7",
+    "description": "Detects leaked Audit debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/audit/debug-trace-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-audit-08",
+    "name": "Audit Debug Trace Log Leak #8",
+    "description": "Detects leaked Audit debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/debug-trace-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-audit-09",
+    "name": "Audit Debug Trace Log Leak #9",
+    "description": "Detects leaked Audit debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/debug-trace-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-audit-10",
+    "name": "Audit Debug Trace Log Leak #10",
+    "description": "Detects leaked Audit debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/debug-trace-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-audit-06",
+    "name": "Audit Database Backup Exposure #6",
+    "description": "Finds exposed Audit database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/db-backup-06.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-audit-07",
+    "name": "Audit Database Backup Exposure #7",
+    "description": "Finds exposed Audit database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/db-backup-07.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-audit-08",
+    "name": "Audit Database Backup Exposure #8",
+    "description": "Finds exposed Audit database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/db-backup-08.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-audit-09",
+    "name": "Audit Database Backup Exposure #9",
+    "description": "Finds exposed Audit database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/db-backup-09.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-audit-10",
+    "name": "Audit Database Backup Exposure #10",
+    "description": "Finds exposed Audit database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/audit/db-backup-10.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-audit-06",
+    "name": "Audit Compliance Report Leak #6",
+    "description": "Detects leaked Audit compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/compliance-report-06.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-audit-07",
+    "name": "Audit Compliance Report Leak #7",
+    "description": "Detects leaked Audit compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/audit/compliance-report-07.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-audit-08",
+    "name": "Audit Compliance Report Leak #8",
+    "description": "Detects leaked Audit compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/compliance-report-08.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-audit-09",
+    "name": "Audit Compliance Report Leak #9",
+    "description": "Detects leaked Audit compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/compliance-report-09.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-audit-10",
+    "name": "Audit Compliance Report Leak #10",
+    "description": "Detects leaked Audit compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/audit/compliance-report-10.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "audit"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-billing-06",
+    "name": "Billing Token Cache Dump #6",
+    "description": "Detects exposed Billing token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/token-cache-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-billing-07",
+    "name": "Billing Token Cache Dump #7",
+    "description": "Detects exposed Billing token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/token-cache-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-billing-08",
+    "name": "Billing Token Cache Dump #8",
+    "description": "Detects exposed Billing token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/token-cache-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-billing-09",
+    "name": "Billing Token Cache Dump #9",
+    "description": "Detects exposed Billing token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/token-cache-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-billing-10",
+    "name": "Billing Token Cache Dump #10",
+    "description": "Detects exposed Billing token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/token-cache-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-billing-06",
+    "name": "Billing Session Ledger Leak #6",
+    "description": "Catches leaked Billing session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/sessions-ledger-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-billing-07",
+    "name": "Billing Session Ledger Leak #7",
+    "description": "Catches leaked Billing session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/sessions-ledger-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-billing-08",
+    "name": "Billing Session Ledger Leak #8",
+    "description": "Catches leaked Billing session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/sessions-ledger-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-billing-09",
+    "name": "Billing Session Ledger Leak #9",
+    "description": "Catches leaked Billing session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/sessions-ledger-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-billing-10",
+    "name": "Billing Session Ledger Leak #10",
+    "description": "Catches leaked Billing session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/sessions-ledger-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-billing-06",
+    "name": "Billing Config Export Exposure #6",
+    "description": "Finds world-readable Billing configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/config-export-06.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-billing-07",
+    "name": "Billing Config Export Exposure #7",
+    "description": "Finds world-readable Billing configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/config-export-07.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-billing-08",
+    "name": "Billing Config Export Exposure #8",
+    "description": "Finds world-readable Billing configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/config-export-08.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-billing-09",
+    "name": "Billing Config Export Exposure #9",
+    "description": "Finds world-readable Billing configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/config-export-09.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-billing-10",
+    "name": "Billing Config Export Exposure #10",
+    "description": "Finds world-readable Billing configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/config-export-10.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-billing-06",
+    "name": "Billing User Dump Exposure #6",
+    "description": "Detects exposed Billing user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/user-dump-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-billing-07",
+    "name": "Billing User Dump Exposure #7",
+    "description": "Detects exposed Billing user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/billing/user-dump-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-billing-08",
+    "name": "Billing User Dump Exposure #8",
+    "description": "Detects exposed Billing user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/user-dump-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-billing-09",
+    "name": "Billing User Dump Exposure #9",
+    "description": "Detects exposed Billing user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/user-dump-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-billing-10",
+    "name": "Billing User Dump Exposure #10",
+    "description": "Detects exposed Billing user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/user-dump-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-billing-06",
+    "name": "Billing Billing Export Exposure #6",
+    "description": "Identifies Billing billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/billing-export-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-billing-07",
+    "name": "Billing Billing Export Exposure #7",
+    "description": "Identifies Billing billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/billing/billing-export-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-billing-08",
+    "name": "Billing Billing Export Exposure #8",
+    "description": "Identifies Billing billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/billing-export-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-billing-09",
+    "name": "Billing Billing Export Exposure #9",
+    "description": "Identifies Billing billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/billing-export-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-billing-10",
+    "name": "Billing Billing Export Exposure #10",
+    "description": "Identifies Billing billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/billing-export-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-billing-06",
+    "name": "Billing Webhook Registry Leak #6",
+    "description": "Detects leaked Billing webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/webhooks-registry-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-billing-07",
+    "name": "Billing Webhook Registry Leak #7",
+    "description": "Detects leaked Billing webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/webhooks-registry-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-billing-08",
+    "name": "Billing Webhook Registry Leak #8",
+    "description": "Detects leaked Billing webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/webhooks-registry-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-billing-09",
+    "name": "Billing Webhook Registry Leak #9",
+    "description": "Detects leaked Billing webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/webhooks-registry-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-billing-10",
+    "name": "Billing Webhook Registry Leak #10",
+    "description": "Detects leaked Billing webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/webhooks-registry-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-billing-06",
+    "name": "Billing Telemetry Snapshot Exposure #6",
+    "description": "Surfaces exposed Billing telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/telemetry-snapshot-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-billing-07",
+    "name": "Billing Telemetry Snapshot Exposure #7",
+    "description": "Surfaces exposed Billing telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/billing/telemetry-snapshot-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-billing-08",
+    "name": "Billing Telemetry Snapshot Exposure #8",
+    "description": "Surfaces exposed Billing telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/telemetry-snapshot-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-billing-09",
+    "name": "Billing Telemetry Snapshot Exposure #9",
+    "description": "Surfaces exposed Billing telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/telemetry-snapshot-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-billing-10",
+    "name": "Billing Telemetry Snapshot Exposure #10",
+    "description": "Surfaces exposed Billing telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/telemetry-snapshot-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-billing-06",
+    "name": "Billing Debug Trace Log Leak #6",
+    "description": "Detects leaked Billing debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/debug-trace-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-billing-07",
+    "name": "Billing Debug Trace Log Leak #7",
+    "description": "Detects leaked Billing debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/billing/debug-trace-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-billing-08",
+    "name": "Billing Debug Trace Log Leak #8",
+    "description": "Detects leaked Billing debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/debug-trace-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-billing-09",
+    "name": "Billing Debug Trace Log Leak #9",
+    "description": "Detects leaked Billing debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/debug-trace-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-billing-10",
+    "name": "Billing Debug Trace Log Leak #10",
+    "description": "Detects leaked Billing debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/debug-trace-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-billing-06",
+    "name": "Billing Database Backup Exposure #6",
+    "description": "Finds exposed Billing database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/db-backup-06.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-billing-07",
+    "name": "Billing Database Backup Exposure #7",
+    "description": "Finds exposed Billing database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/db-backup-07.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-billing-08",
+    "name": "Billing Database Backup Exposure #8",
+    "description": "Finds exposed Billing database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/db-backup-08.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-billing-09",
+    "name": "Billing Database Backup Exposure #9",
+    "description": "Finds exposed Billing database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/db-backup-09.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-billing-10",
+    "name": "Billing Database Backup Exposure #10",
+    "description": "Finds exposed Billing database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/billing/db-backup-10.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-billing-06",
+    "name": "Billing Compliance Report Leak #6",
+    "description": "Detects leaked Billing compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/compliance-report-06.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-billing-07",
+    "name": "Billing Compliance Report Leak #7",
+    "description": "Detects leaked Billing compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/billing/compliance-report-07.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-billing-08",
+    "name": "Billing Compliance Report Leak #8",
+    "description": "Detects leaked Billing compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/compliance-report-08.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-billing-09",
+    "name": "Billing Compliance Report Leak #9",
+    "description": "Detects leaked Billing compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/compliance-report-09.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-billing-10",
+    "name": "Billing Compliance Report Leak #10",
+    "description": "Detects leaked Billing compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/billing/compliance-report-10.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "billing"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-business-intelligence-06",
+    "name": "Business Intelligence Token Cache Dump #6",
+    "description": "Detects exposed Business Intelligence token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/token-cache-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-business-intelligence-07",
+    "name": "Business Intelligence Token Cache Dump #7",
+    "description": "Detects exposed Business Intelligence token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/token-cache-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-business-intelligence-08",
+    "name": "Business Intelligence Token Cache Dump #8",
+    "description": "Detects exposed Business Intelligence token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/token-cache-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-business-intelligence-09",
+    "name": "Business Intelligence Token Cache Dump #9",
+    "description": "Detects exposed Business Intelligence token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/token-cache-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-business-intelligence-10",
+    "name": "Business Intelligence Token Cache Dump #10",
+    "description": "Detects exposed Business Intelligence token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/token-cache-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-business-intelligence-06",
+    "name": "Business Intelligence Session Ledger Leak #6",
+    "description": "Catches leaked Business Intelligence session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/sessions-ledger-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-business-intelligence-07",
+    "name": "Business Intelligence Session Ledger Leak #7",
+    "description": "Catches leaked Business Intelligence session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/sessions-ledger-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-business-intelligence-08",
+    "name": "Business Intelligence Session Ledger Leak #8",
+    "description": "Catches leaked Business Intelligence session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/sessions-ledger-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-business-intelligence-09",
+    "name": "Business Intelligence Session Ledger Leak #9",
+    "description": "Catches leaked Business Intelligence session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/sessions-ledger-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-business-intelligence-10",
+    "name": "Business Intelligence Session Ledger Leak #10",
+    "description": "Catches leaked Business Intelligence session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/sessions-ledger-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-business-intelligence-06",
+    "name": "Business Intelligence Config Export Exposure #6",
+    "description": "Finds world-readable Business Intelligence configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/config-export-06.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-business-intelligence-07",
+    "name": "Business Intelligence Config Export Exposure #7",
+    "description": "Finds world-readable Business Intelligence configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/config-export-07.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-business-intelligence-08",
+    "name": "Business Intelligence Config Export Exposure #8",
+    "description": "Finds world-readable Business Intelligence configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/config-export-08.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-business-intelligence-09",
+    "name": "Business Intelligence Config Export Exposure #9",
+    "description": "Finds world-readable Business Intelligence configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/config-export-09.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-business-intelligence-10",
+    "name": "Business Intelligence Config Export Exposure #10",
+    "description": "Finds world-readable Business Intelligence configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/config-export-10.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-business-intelligence-06",
+    "name": "Business Intelligence User Dump Exposure #6",
+    "description": "Detects exposed Business Intelligence user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/user-dump-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-business-intelligence-07",
+    "name": "Business Intelligence User Dump Exposure #7",
+    "description": "Detects exposed Business Intelligence user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/business-intelligence/user-dump-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-business-intelligence-08",
+    "name": "Business Intelligence User Dump Exposure #8",
+    "description": "Detects exposed Business Intelligence user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/user-dump-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-business-intelligence-09",
+    "name": "Business Intelligence User Dump Exposure #9",
+    "description": "Detects exposed Business Intelligence user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/user-dump-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-business-intelligence-10",
+    "name": "Business Intelligence User Dump Exposure #10",
+    "description": "Detects exposed Business Intelligence user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/user-dump-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-business-intelligence-06",
+    "name": "Business Intelligence Billing Export Exposure #6",
+    "description": "Identifies Business Intelligence billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/billing-export-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-business-intelligence-07",
+    "name": "Business Intelligence Billing Export Exposure #7",
+    "description": "Identifies Business Intelligence billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/business-intelligence/billing-export-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-business-intelligence-08",
+    "name": "Business Intelligence Billing Export Exposure #8",
+    "description": "Identifies Business Intelligence billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/billing-export-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-business-intelligence-09",
+    "name": "Business Intelligence Billing Export Exposure #9",
+    "description": "Identifies Business Intelligence billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/billing-export-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-business-intelligence-10",
+    "name": "Business Intelligence Billing Export Exposure #10",
+    "description": "Identifies Business Intelligence billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/billing-export-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-business-intelligence-06",
+    "name": "Business Intelligence Webhook Registry Leak #6",
+    "description": "Detects leaked Business Intelligence webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/webhooks-registry-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-business-intelligence-07",
+    "name": "Business Intelligence Webhook Registry Leak #7",
+    "description": "Detects leaked Business Intelligence webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/webhooks-registry-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-business-intelligence-08",
+    "name": "Business Intelligence Webhook Registry Leak #8",
+    "description": "Detects leaked Business Intelligence webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/webhooks-registry-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-business-intelligence-09",
+    "name": "Business Intelligence Webhook Registry Leak #9",
+    "description": "Detects leaked Business Intelligence webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/webhooks-registry-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-business-intelligence-10",
+    "name": "Business Intelligence Webhook Registry Leak #10",
+    "description": "Detects leaked Business Intelligence webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/webhooks-registry-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-business-intelligence-06",
+    "name": "Business Intelligence Telemetry Snapshot Exposure #6",
+    "description": "Surfaces exposed Business Intelligence telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/telemetry-snapshot-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-business-intelligence-07",
+    "name": "Business Intelligence Telemetry Snapshot Exposure #7",
+    "description": "Surfaces exposed Business Intelligence telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/business-intelligence/telemetry-snapshot-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-business-intelligence-08",
+    "name": "Business Intelligence Telemetry Snapshot Exposure #8",
+    "description": "Surfaces exposed Business Intelligence telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/telemetry-snapshot-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-business-intelligence-09",
+    "name": "Business Intelligence Telemetry Snapshot Exposure #9",
+    "description": "Surfaces exposed Business Intelligence telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/telemetry-snapshot-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-business-intelligence-10",
+    "name": "Business Intelligence Telemetry Snapshot Exposure #10",
+    "description": "Surfaces exposed Business Intelligence telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/telemetry-snapshot-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-business-intelligence-06",
+    "name": "Business Intelligence Debug Trace Log Leak #6",
+    "description": "Detects leaked Business Intelligence debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/debug-trace-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-business-intelligence-07",
+    "name": "Business Intelligence Debug Trace Log Leak #7",
+    "description": "Detects leaked Business Intelligence debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/business-intelligence/debug-trace-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-business-intelligence-08",
+    "name": "Business Intelligence Debug Trace Log Leak #8",
+    "description": "Detects leaked Business Intelligence debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/debug-trace-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-business-intelligence-09",
+    "name": "Business Intelligence Debug Trace Log Leak #9",
+    "description": "Detects leaked Business Intelligence debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/debug-trace-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-business-intelligence-10",
+    "name": "Business Intelligence Debug Trace Log Leak #10",
+    "description": "Detects leaked Business Intelligence debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/debug-trace-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-business-intelligence-06",
+    "name": "Business Intelligence Database Backup Exposure #6",
+    "description": "Finds exposed Business Intelligence database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/db-backup-06.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-business-intelligence-07",
+    "name": "Business Intelligence Database Backup Exposure #7",
+    "description": "Finds exposed Business Intelligence database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/db-backup-07.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-business-intelligence-08",
+    "name": "Business Intelligence Database Backup Exposure #8",
+    "description": "Finds exposed Business Intelligence database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/db-backup-08.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-business-intelligence-09",
+    "name": "Business Intelligence Database Backup Exposure #9",
+    "description": "Finds exposed Business Intelligence database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/db-backup-09.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-business-intelligence-10",
+    "name": "Business Intelligence Database Backup Exposure #10",
+    "description": "Finds exposed Business Intelligence database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/business-intelligence/db-backup-10.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-business-intelligence-06",
+    "name": "Business Intelligence Compliance Report Leak #6",
+    "description": "Detects leaked Business Intelligence compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/compliance-report-06.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-business-intelligence-07",
+    "name": "Business Intelligence Compliance Report Leak #7",
+    "description": "Detects leaked Business Intelligence compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/business-intelligence/compliance-report-07.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-business-intelligence-08",
+    "name": "Business Intelligence Compliance Report Leak #8",
+    "description": "Detects leaked Business Intelligence compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/compliance-report-08.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-business-intelligence-09",
+    "name": "Business Intelligence Compliance Report Leak #9",
+    "description": "Detects leaked Business Intelligence compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/compliance-report-09.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-business-intelligence-10",
+    "name": "Business Intelligence Compliance Report Leak #10",
+    "description": "Detects leaked Business Intelligence compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/business-intelligence/compliance-report-10.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "business-intelligence"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-cloud-ops-06",
+    "name": "Cloud Ops Token Cache Dump #6",
+    "description": "Detects exposed Cloud Ops token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/token-cache-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-cloud-ops-07",
+    "name": "Cloud Ops Token Cache Dump #7",
+    "description": "Detects exposed Cloud Ops token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/token-cache-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-cloud-ops-08",
+    "name": "Cloud Ops Token Cache Dump #8",
+    "description": "Detects exposed Cloud Ops token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/token-cache-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-cloud-ops-09",
+    "name": "Cloud Ops Token Cache Dump #9",
+    "description": "Detects exposed Cloud Ops token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/token-cache-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-cloud-ops-10",
+    "name": "Cloud Ops Token Cache Dump #10",
+    "description": "Detects exposed Cloud Ops token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/token-cache-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-cloud-ops-06",
+    "name": "Cloud Ops Session Ledger Leak #6",
+    "description": "Catches leaked Cloud Ops session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/sessions-ledger-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-cloud-ops-07",
+    "name": "Cloud Ops Session Ledger Leak #7",
+    "description": "Catches leaked Cloud Ops session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/sessions-ledger-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-cloud-ops-08",
+    "name": "Cloud Ops Session Ledger Leak #8",
+    "description": "Catches leaked Cloud Ops session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/sessions-ledger-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-cloud-ops-09",
+    "name": "Cloud Ops Session Ledger Leak #9",
+    "description": "Catches leaked Cloud Ops session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/sessions-ledger-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-cloud-ops-10",
+    "name": "Cloud Ops Session Ledger Leak #10",
+    "description": "Catches leaked Cloud Ops session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/sessions-ledger-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-cloud-ops-06",
+    "name": "Cloud Ops Config Export Exposure #6",
+    "description": "Finds world-readable Cloud Ops configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/config-export-06.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-cloud-ops-07",
+    "name": "Cloud Ops Config Export Exposure #7",
+    "description": "Finds world-readable Cloud Ops configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/config-export-07.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-cloud-ops-08",
+    "name": "Cloud Ops Config Export Exposure #8",
+    "description": "Finds world-readable Cloud Ops configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/config-export-08.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-cloud-ops-09",
+    "name": "Cloud Ops Config Export Exposure #9",
+    "description": "Finds world-readable Cloud Ops configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/config-export-09.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-cloud-ops-10",
+    "name": "Cloud Ops Config Export Exposure #10",
+    "description": "Finds world-readable Cloud Ops configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/config-export-10.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-cloud-ops-06",
+    "name": "Cloud Ops User Dump Exposure #6",
+    "description": "Detects exposed Cloud Ops user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/user-dump-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-cloud-ops-07",
+    "name": "Cloud Ops User Dump Exposure #7",
+    "description": "Detects exposed Cloud Ops user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/cloud-ops/user-dump-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-cloud-ops-08",
+    "name": "Cloud Ops User Dump Exposure #8",
+    "description": "Detects exposed Cloud Ops user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/user-dump-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-cloud-ops-09",
+    "name": "Cloud Ops User Dump Exposure #9",
+    "description": "Detects exposed Cloud Ops user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/user-dump-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-cloud-ops-10",
+    "name": "Cloud Ops User Dump Exposure #10",
+    "description": "Detects exposed Cloud Ops user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/user-dump-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-cloud-ops-06",
+    "name": "Cloud Ops Billing Export Exposure #6",
+    "description": "Identifies Cloud Ops billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/billing-export-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-cloud-ops-07",
+    "name": "Cloud Ops Billing Export Exposure #7",
+    "description": "Identifies Cloud Ops billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/cloud-ops/billing-export-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-cloud-ops-08",
+    "name": "Cloud Ops Billing Export Exposure #8",
+    "description": "Identifies Cloud Ops billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/billing-export-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-cloud-ops-09",
+    "name": "Cloud Ops Billing Export Exposure #9",
+    "description": "Identifies Cloud Ops billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/billing-export-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-cloud-ops-10",
+    "name": "Cloud Ops Billing Export Exposure #10",
+    "description": "Identifies Cloud Ops billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/billing-export-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-cloud-ops-06",
+    "name": "Cloud Ops Webhook Registry Leak #6",
+    "description": "Detects leaked Cloud Ops webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/webhooks-registry-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-cloud-ops-07",
+    "name": "Cloud Ops Webhook Registry Leak #7",
+    "description": "Detects leaked Cloud Ops webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/webhooks-registry-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-cloud-ops-08",
+    "name": "Cloud Ops Webhook Registry Leak #8",
+    "description": "Detects leaked Cloud Ops webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/webhooks-registry-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-cloud-ops-09",
+    "name": "Cloud Ops Webhook Registry Leak #9",
+    "description": "Detects leaked Cloud Ops webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/webhooks-registry-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-cloud-ops-10",
+    "name": "Cloud Ops Webhook Registry Leak #10",
+    "description": "Detects leaked Cloud Ops webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/webhooks-registry-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-cloud-ops-06",
+    "name": "Cloud Ops Telemetry Snapshot Exposure #6",
+    "description": "Surfaces exposed Cloud Ops telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/telemetry-snapshot-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-cloud-ops-07",
+    "name": "Cloud Ops Telemetry Snapshot Exposure #7",
+    "description": "Surfaces exposed Cloud Ops telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/cloud-ops/telemetry-snapshot-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-cloud-ops-08",
+    "name": "Cloud Ops Telemetry Snapshot Exposure #8",
+    "description": "Surfaces exposed Cloud Ops telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/telemetry-snapshot-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-cloud-ops-09",
+    "name": "Cloud Ops Telemetry Snapshot Exposure #9",
+    "description": "Surfaces exposed Cloud Ops telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/telemetry-snapshot-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-cloud-ops-10",
+    "name": "Cloud Ops Telemetry Snapshot Exposure #10",
+    "description": "Surfaces exposed Cloud Ops telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/telemetry-snapshot-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-cloud-ops-06",
+    "name": "Cloud Ops Debug Trace Log Leak #6",
+    "description": "Detects leaked Cloud Ops debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/debug-trace-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-cloud-ops-07",
+    "name": "Cloud Ops Debug Trace Log Leak #7",
+    "description": "Detects leaked Cloud Ops debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/cloud-ops/debug-trace-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-cloud-ops-08",
+    "name": "Cloud Ops Debug Trace Log Leak #8",
+    "description": "Detects leaked Cloud Ops debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/debug-trace-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-cloud-ops-09",
+    "name": "Cloud Ops Debug Trace Log Leak #9",
+    "description": "Detects leaked Cloud Ops debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/debug-trace-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-cloud-ops-10",
+    "name": "Cloud Ops Debug Trace Log Leak #10",
+    "description": "Detects leaked Cloud Ops debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/debug-trace-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-cloud-ops-06",
+    "name": "Cloud Ops Database Backup Exposure #6",
+    "description": "Finds exposed Cloud Ops database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/db-backup-06.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-cloud-ops-07",
+    "name": "Cloud Ops Database Backup Exposure #7",
+    "description": "Finds exposed Cloud Ops database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/db-backup-07.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-cloud-ops-08",
+    "name": "Cloud Ops Database Backup Exposure #8",
+    "description": "Finds exposed Cloud Ops database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/db-backup-08.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-cloud-ops-09",
+    "name": "Cloud Ops Database Backup Exposure #9",
+    "description": "Finds exposed Cloud Ops database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/db-backup-09.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-cloud-ops-10",
+    "name": "Cloud Ops Database Backup Exposure #10",
+    "description": "Finds exposed Cloud Ops database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/cloud-ops/db-backup-10.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-cloud-ops-06",
+    "name": "Cloud Ops Compliance Report Leak #6",
+    "description": "Detects leaked Cloud Ops compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/compliance-report-06.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-cloud-ops-07",
+    "name": "Cloud Ops Compliance Report Leak #7",
+    "description": "Detects leaked Cloud Ops compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/cloud-ops/compliance-report-07.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-cloud-ops-08",
+    "name": "Cloud Ops Compliance Report Leak #8",
+    "description": "Detects leaked Cloud Ops compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/compliance-report-08.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-cloud-ops-09",
+    "name": "Cloud Ops Compliance Report Leak #9",
+    "description": "Detects leaked Cloud Ops compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/compliance-report-09.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-cloud-ops-10",
+    "name": "Cloud Ops Compliance Report Leak #10",
+    "description": "Detects leaked Cloud Ops compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/cloud-ops/compliance-report-10.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "cloud-ops"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-collaboration-06",
+    "name": "Collaboration Token Cache Dump #6",
+    "description": "Detects exposed Collaboration token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/token-cache-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-collaboration-07",
+    "name": "Collaboration Token Cache Dump #7",
+    "description": "Detects exposed Collaboration token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/token-cache-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-collaboration-08",
+    "name": "Collaboration Token Cache Dump #8",
+    "description": "Detects exposed Collaboration token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/token-cache-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-collaboration-09",
+    "name": "Collaboration Token Cache Dump #9",
+    "description": "Detects exposed Collaboration token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/token-cache-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-collaboration-10",
+    "name": "Collaboration Token Cache Dump #10",
+    "description": "Detects exposed Collaboration token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/token-cache-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-collaboration-06",
+    "name": "Collaboration Session Ledger Leak #6",
+    "description": "Catches leaked Collaboration session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/sessions-ledger-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-collaboration-07",
+    "name": "Collaboration Session Ledger Leak #7",
+    "description": "Catches leaked Collaboration session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/sessions-ledger-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-collaboration-08",
+    "name": "Collaboration Session Ledger Leak #8",
+    "description": "Catches leaked Collaboration session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/sessions-ledger-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-collaboration-09",
+    "name": "Collaboration Session Ledger Leak #9",
+    "description": "Catches leaked Collaboration session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/sessions-ledger-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-collaboration-10",
+    "name": "Collaboration Session Ledger Leak #10",
+    "description": "Catches leaked Collaboration session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/sessions-ledger-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-collaboration-06",
+    "name": "Collaboration Config Export Exposure #6",
+    "description": "Finds world-readable Collaboration configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/config-export-06.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-collaboration-07",
+    "name": "Collaboration Config Export Exposure #7",
+    "description": "Finds world-readable Collaboration configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/config-export-07.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-collaboration-08",
+    "name": "Collaboration Config Export Exposure #8",
+    "description": "Finds world-readable Collaboration configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/config-export-08.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-collaboration-09",
+    "name": "Collaboration Config Export Exposure #9",
+    "description": "Finds world-readable Collaboration configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/config-export-09.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-collaboration-10",
+    "name": "Collaboration Config Export Exposure #10",
+    "description": "Finds world-readable Collaboration configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/config-export-10.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-collaboration-06",
+    "name": "Collaboration User Dump Exposure #6",
+    "description": "Detects exposed Collaboration user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/user-dump-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-collaboration-07",
+    "name": "Collaboration User Dump Exposure #7",
+    "description": "Detects exposed Collaboration user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/collaboration/user-dump-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-collaboration-08",
+    "name": "Collaboration User Dump Exposure #8",
+    "description": "Detects exposed Collaboration user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/user-dump-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-collaboration-09",
+    "name": "Collaboration User Dump Exposure #9",
+    "description": "Detects exposed Collaboration user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/user-dump-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-collaboration-10",
+    "name": "Collaboration User Dump Exposure #10",
+    "description": "Detects exposed Collaboration user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/user-dump-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-collaboration-06",
+    "name": "Collaboration Billing Export Exposure #6",
+    "description": "Identifies Collaboration billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/billing-export-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-collaboration-07",
+    "name": "Collaboration Billing Export Exposure #7",
+    "description": "Identifies Collaboration billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/collaboration/billing-export-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-collaboration-08",
+    "name": "Collaboration Billing Export Exposure #8",
+    "description": "Identifies Collaboration billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/billing-export-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-collaboration-09",
+    "name": "Collaboration Billing Export Exposure #9",
+    "description": "Identifies Collaboration billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/billing-export-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-collaboration-10",
+    "name": "Collaboration Billing Export Exposure #10",
+    "description": "Identifies Collaboration billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/billing-export-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-collaboration-06",
+    "name": "Collaboration Webhook Registry Leak #6",
+    "description": "Detects leaked Collaboration webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/webhooks-registry-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-collaboration-07",
+    "name": "Collaboration Webhook Registry Leak #7",
+    "description": "Detects leaked Collaboration webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/webhooks-registry-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-collaboration-08",
+    "name": "Collaboration Webhook Registry Leak #8",
+    "description": "Detects leaked Collaboration webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/webhooks-registry-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-collaboration-09",
+    "name": "Collaboration Webhook Registry Leak #9",
+    "description": "Detects leaked Collaboration webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/webhooks-registry-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-collaboration-10",
+    "name": "Collaboration Webhook Registry Leak #10",
+    "description": "Detects leaked Collaboration webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/webhooks-registry-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-collaboration-06",
+    "name": "Collaboration Telemetry Snapshot Exposure #6",
+    "description": "Surfaces exposed Collaboration telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/telemetry-snapshot-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-collaboration-07",
+    "name": "Collaboration Telemetry Snapshot Exposure #7",
+    "description": "Surfaces exposed Collaboration telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/collaboration/telemetry-snapshot-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-collaboration-08",
+    "name": "Collaboration Telemetry Snapshot Exposure #8",
+    "description": "Surfaces exposed Collaboration telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/telemetry-snapshot-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-collaboration-09",
+    "name": "Collaboration Telemetry Snapshot Exposure #9",
+    "description": "Surfaces exposed Collaboration telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/telemetry-snapshot-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-collaboration-10",
+    "name": "Collaboration Telemetry Snapshot Exposure #10",
+    "description": "Surfaces exposed Collaboration telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/telemetry-snapshot-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-collaboration-06",
+    "name": "Collaboration Debug Trace Log Leak #6",
+    "description": "Detects leaked Collaboration debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/debug-trace-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-collaboration-07",
+    "name": "Collaboration Debug Trace Log Leak #7",
+    "description": "Detects leaked Collaboration debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/collaboration/debug-trace-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-collaboration-08",
+    "name": "Collaboration Debug Trace Log Leak #8",
+    "description": "Detects leaked Collaboration debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/debug-trace-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-collaboration-09",
+    "name": "Collaboration Debug Trace Log Leak #9",
+    "description": "Detects leaked Collaboration debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/debug-trace-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-collaboration-10",
+    "name": "Collaboration Debug Trace Log Leak #10",
+    "description": "Detects leaked Collaboration debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/debug-trace-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-collaboration-06",
+    "name": "Collaboration Database Backup Exposure #6",
+    "description": "Finds exposed Collaboration database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/db-backup-06.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-collaboration-07",
+    "name": "Collaboration Database Backup Exposure #7",
+    "description": "Finds exposed Collaboration database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/db-backup-07.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-collaboration-08",
+    "name": "Collaboration Database Backup Exposure #8",
+    "description": "Finds exposed Collaboration database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/db-backup-08.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-collaboration-09",
+    "name": "Collaboration Database Backup Exposure #9",
+    "description": "Finds exposed Collaboration database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/db-backup-09.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-collaboration-10",
+    "name": "Collaboration Database Backup Exposure #10",
+    "description": "Finds exposed Collaboration database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/collaboration/db-backup-10.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-collaboration-06",
+    "name": "Collaboration Compliance Report Leak #6",
+    "description": "Detects leaked Collaboration compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/compliance-report-06.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-collaboration-07",
+    "name": "Collaboration Compliance Report Leak #7",
+    "description": "Detects leaked Collaboration compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/collaboration/compliance-report-07.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-collaboration-08",
+    "name": "Collaboration Compliance Report Leak #8",
+    "description": "Detects leaked Collaboration compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/compliance-report-08.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-collaboration-09",
+    "name": "Collaboration Compliance Report Leak #9",
+    "description": "Detects leaked Collaboration compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/compliance-report-09.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-collaboration-10",
+    "name": "Collaboration Compliance Report Leak #10",
+    "description": "Detects leaked Collaboration compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/collaboration/compliance-report-10.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "collaboration"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-commerce-06",
+    "name": "Commerce Token Cache Dump #6",
+    "description": "Detects exposed Commerce token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/token-cache-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-commerce-07",
+    "name": "Commerce Token Cache Dump #7",
+    "description": "Detects exposed Commerce token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/token-cache-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-commerce-08",
+    "name": "Commerce Token Cache Dump #8",
+    "description": "Detects exposed Commerce token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/token-cache-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-commerce-09",
+    "name": "Commerce Token Cache Dump #9",
+    "description": "Detects exposed Commerce token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/token-cache-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-commerce-10",
+    "name": "Commerce Token Cache Dump #10",
+    "description": "Detects exposed Commerce token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/token-cache-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-commerce-06",
+    "name": "Commerce Session Ledger Leak #6",
+    "description": "Catches leaked Commerce session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/sessions-ledger-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-commerce-07",
+    "name": "Commerce Session Ledger Leak #7",
+    "description": "Catches leaked Commerce session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/sessions-ledger-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-commerce-08",
+    "name": "Commerce Session Ledger Leak #8",
+    "description": "Catches leaked Commerce session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/sessions-ledger-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-commerce-09",
+    "name": "Commerce Session Ledger Leak #9",
+    "description": "Catches leaked Commerce session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/sessions-ledger-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-commerce-10",
+    "name": "Commerce Session Ledger Leak #10",
+    "description": "Catches leaked Commerce session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/sessions-ledger-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-commerce-06",
+    "name": "Commerce Config Export Exposure #6",
+    "description": "Finds world-readable Commerce configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/config-export-06.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-commerce-07",
+    "name": "Commerce Config Export Exposure #7",
+    "description": "Finds world-readable Commerce configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/config-export-07.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-commerce-08",
+    "name": "Commerce Config Export Exposure #8",
+    "description": "Finds world-readable Commerce configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/config-export-08.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-commerce-09",
+    "name": "Commerce Config Export Exposure #9",
+    "description": "Finds world-readable Commerce configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/config-export-09.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-commerce-10",
+    "name": "Commerce Config Export Exposure #10",
+    "description": "Finds world-readable Commerce configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/config-export-10.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-commerce-06",
+    "name": "Commerce User Dump Exposure #6",
+    "description": "Detects exposed Commerce user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/user-dump-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-commerce-07",
+    "name": "Commerce User Dump Exposure #7",
+    "description": "Detects exposed Commerce user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/commerce/user-dump-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-commerce-08",
+    "name": "Commerce User Dump Exposure #8",
+    "description": "Detects exposed Commerce user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/user-dump-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-commerce-09",
+    "name": "Commerce User Dump Exposure #9",
+    "description": "Detects exposed Commerce user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/user-dump-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-commerce-10",
+    "name": "Commerce User Dump Exposure #10",
+    "description": "Detects exposed Commerce user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/user-dump-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-commerce-06",
+    "name": "Commerce Billing Export Exposure #6",
+    "description": "Identifies Commerce billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/billing-export-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-commerce-07",
+    "name": "Commerce Billing Export Exposure #7",
+    "description": "Identifies Commerce billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/commerce/billing-export-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-commerce-08",
+    "name": "Commerce Billing Export Exposure #8",
+    "description": "Identifies Commerce billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/billing-export-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-commerce-09",
+    "name": "Commerce Billing Export Exposure #9",
+    "description": "Identifies Commerce billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/billing-export-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-commerce-10",
+    "name": "Commerce Billing Export Exposure #10",
+    "description": "Identifies Commerce billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/billing-export-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-commerce-06",
+    "name": "Commerce Webhook Registry Leak #6",
+    "description": "Detects leaked Commerce webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/webhooks-registry-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-commerce-07",
+    "name": "Commerce Webhook Registry Leak #7",
+    "description": "Detects leaked Commerce webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/webhooks-registry-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-commerce-08",
+    "name": "Commerce Webhook Registry Leak #8",
+    "description": "Detects leaked Commerce webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/webhooks-registry-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-commerce-09",
+    "name": "Commerce Webhook Registry Leak #9",
+    "description": "Detects leaked Commerce webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/webhooks-registry-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-commerce-10",
+    "name": "Commerce Webhook Registry Leak #10",
+    "description": "Detects leaked Commerce webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/webhooks-registry-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-commerce-06",
+    "name": "Commerce Telemetry Snapshot Exposure #6",
+    "description": "Surfaces exposed Commerce telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/telemetry-snapshot-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-commerce-07",
+    "name": "Commerce Telemetry Snapshot Exposure #7",
+    "description": "Surfaces exposed Commerce telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/commerce/telemetry-snapshot-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-commerce-08",
+    "name": "Commerce Telemetry Snapshot Exposure #8",
+    "description": "Surfaces exposed Commerce telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/telemetry-snapshot-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-commerce-09",
+    "name": "Commerce Telemetry Snapshot Exposure #9",
+    "description": "Surfaces exposed Commerce telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/telemetry-snapshot-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-commerce-10",
+    "name": "Commerce Telemetry Snapshot Exposure #10",
+    "description": "Surfaces exposed Commerce telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/telemetry-snapshot-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-commerce-06",
+    "name": "Commerce Debug Trace Log Leak #6",
+    "description": "Detects leaked Commerce debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/debug-trace-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-commerce-07",
+    "name": "Commerce Debug Trace Log Leak #7",
+    "description": "Detects leaked Commerce debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/commerce/debug-trace-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-commerce-08",
+    "name": "Commerce Debug Trace Log Leak #8",
+    "description": "Detects leaked Commerce debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/debug-trace-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-commerce-09",
+    "name": "Commerce Debug Trace Log Leak #9",
+    "description": "Detects leaked Commerce debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/debug-trace-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-commerce-10",
+    "name": "Commerce Debug Trace Log Leak #10",
+    "description": "Detects leaked Commerce debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/debug-trace-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-commerce-06",
+    "name": "Commerce Database Backup Exposure #6",
+    "description": "Finds exposed Commerce database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/db-backup-06.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-commerce-07",
+    "name": "Commerce Database Backup Exposure #7",
+    "description": "Finds exposed Commerce database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/db-backup-07.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-commerce-08",
+    "name": "Commerce Database Backup Exposure #8",
+    "description": "Finds exposed Commerce database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/db-backup-08.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-commerce-09",
+    "name": "Commerce Database Backup Exposure #9",
+    "description": "Finds exposed Commerce database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/db-backup-09.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-commerce-10",
+    "name": "Commerce Database Backup Exposure #10",
+    "description": "Finds exposed Commerce database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/commerce/db-backup-10.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-commerce-06",
+    "name": "Commerce Compliance Report Leak #6",
+    "description": "Detects leaked Commerce compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/compliance-report-06.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-commerce-07",
+    "name": "Commerce Compliance Report Leak #7",
+    "description": "Detects leaked Commerce compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/commerce/compliance-report-07.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-commerce-08",
+    "name": "Commerce Compliance Report Leak #8",
+    "description": "Detects leaked Commerce compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/compliance-report-08.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-commerce-09",
+    "name": "Commerce Compliance Report Leak #9",
+    "description": "Detects leaked Commerce compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/compliance-report-09.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-commerce-10",
+    "name": "Commerce Compliance Report Leak #10",
+    "description": "Detects leaked Commerce compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/commerce/compliance-report-10.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "commerce"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-compliance-06",
+    "name": "Compliance Token Cache Dump #6",
+    "description": "Detects exposed Compliance token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/token-cache-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-compliance-07",
+    "name": "Compliance Token Cache Dump #7",
+    "description": "Detects exposed Compliance token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/token-cache-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-compliance-08",
+    "name": "Compliance Token Cache Dump #8",
+    "description": "Detects exposed Compliance token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/token-cache-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-compliance-09",
+    "name": "Compliance Token Cache Dump #9",
+    "description": "Detects exposed Compliance token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/token-cache-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-compliance-10",
+    "name": "Compliance Token Cache Dump #10",
+    "description": "Detects exposed Compliance token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/token-cache-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-compliance-06",
+    "name": "Compliance Session Ledger Leak #6",
+    "description": "Catches leaked Compliance session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/sessions-ledger-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-compliance-07",
+    "name": "Compliance Session Ledger Leak #7",
+    "description": "Catches leaked Compliance session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/sessions-ledger-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-compliance-08",
+    "name": "Compliance Session Ledger Leak #8",
+    "description": "Catches leaked Compliance session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/sessions-ledger-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-compliance-09",
+    "name": "Compliance Session Ledger Leak #9",
+    "description": "Catches leaked Compliance session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/sessions-ledger-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-compliance-10",
+    "name": "Compliance Session Ledger Leak #10",
+    "description": "Catches leaked Compliance session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/sessions-ledger-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-compliance-06",
+    "name": "Compliance Config Export Exposure #6",
+    "description": "Finds world-readable Compliance configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/config-export-06.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-compliance-07",
+    "name": "Compliance Config Export Exposure #7",
+    "description": "Finds world-readable Compliance configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/config-export-07.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-compliance-08",
+    "name": "Compliance Config Export Exposure #8",
+    "description": "Finds world-readable Compliance configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/config-export-08.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-compliance-09",
+    "name": "Compliance Config Export Exposure #9",
+    "description": "Finds world-readable Compliance configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/config-export-09.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-compliance-10",
+    "name": "Compliance Config Export Exposure #10",
+    "description": "Finds world-readable Compliance configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/config-export-10.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-compliance-06",
+    "name": "Compliance User Dump Exposure #6",
+    "description": "Detects exposed Compliance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/user-dump-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-compliance-07",
+    "name": "Compliance User Dump Exposure #7",
+    "description": "Detects exposed Compliance user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/compliance/user-dump-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-compliance-08",
+    "name": "Compliance User Dump Exposure #8",
+    "description": "Detects exposed Compliance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/user-dump-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-compliance-09",
+    "name": "Compliance User Dump Exposure #9",
+    "description": "Detects exposed Compliance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/user-dump-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-compliance-10",
+    "name": "Compliance User Dump Exposure #10",
+    "description": "Detects exposed Compliance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/user-dump-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-compliance-06",
+    "name": "Compliance Billing Export Exposure #6",
+    "description": "Identifies Compliance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/billing-export-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-compliance-07",
+    "name": "Compliance Billing Export Exposure #7",
+    "description": "Identifies Compliance billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/compliance/billing-export-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-compliance-08",
+    "name": "Compliance Billing Export Exposure #8",
+    "description": "Identifies Compliance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/billing-export-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-compliance-09",
+    "name": "Compliance Billing Export Exposure #9",
+    "description": "Identifies Compliance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/billing-export-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-compliance-10",
+    "name": "Compliance Billing Export Exposure #10",
+    "description": "Identifies Compliance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/billing-export-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-compliance-06",
+    "name": "Compliance Webhook Registry Leak #6",
+    "description": "Detects leaked Compliance webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/webhooks-registry-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-compliance-07",
+    "name": "Compliance Webhook Registry Leak #7",
+    "description": "Detects leaked Compliance webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/webhooks-registry-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-compliance-08",
+    "name": "Compliance Webhook Registry Leak #8",
+    "description": "Detects leaked Compliance webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/webhooks-registry-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-compliance-09",
+    "name": "Compliance Webhook Registry Leak #9",
+    "description": "Detects leaked Compliance webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/webhooks-registry-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-compliance-10",
+    "name": "Compliance Webhook Registry Leak #10",
+    "description": "Detects leaked Compliance webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/webhooks-registry-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-compliance-06",
+    "name": "Compliance Telemetry Snapshot Exposure #6",
+    "description": "Surfaces exposed Compliance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/telemetry-snapshot-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-compliance-07",
+    "name": "Compliance Telemetry Snapshot Exposure #7",
+    "description": "Surfaces exposed Compliance telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/compliance/telemetry-snapshot-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-compliance-08",
+    "name": "Compliance Telemetry Snapshot Exposure #8",
+    "description": "Surfaces exposed Compliance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/telemetry-snapshot-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-compliance-09",
+    "name": "Compliance Telemetry Snapshot Exposure #9",
+    "description": "Surfaces exposed Compliance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/telemetry-snapshot-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-compliance-10",
+    "name": "Compliance Telemetry Snapshot Exposure #10",
+    "description": "Surfaces exposed Compliance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/telemetry-snapshot-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-compliance-06",
+    "name": "Compliance Debug Trace Log Leak #6",
+    "description": "Detects leaked Compliance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/debug-trace-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-compliance-07",
+    "name": "Compliance Debug Trace Log Leak #7",
+    "description": "Detects leaked Compliance debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/compliance/debug-trace-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-compliance-08",
+    "name": "Compliance Debug Trace Log Leak #8",
+    "description": "Detects leaked Compliance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/debug-trace-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-compliance-09",
+    "name": "Compliance Debug Trace Log Leak #9",
+    "description": "Detects leaked Compliance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/debug-trace-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-compliance-10",
+    "name": "Compliance Debug Trace Log Leak #10",
+    "description": "Detects leaked Compliance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/debug-trace-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-compliance-06",
+    "name": "Compliance Database Backup Exposure #6",
+    "description": "Finds exposed Compliance database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/db-backup-06.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-compliance-07",
+    "name": "Compliance Database Backup Exposure #7",
+    "description": "Finds exposed Compliance database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/db-backup-07.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-compliance-08",
+    "name": "Compliance Database Backup Exposure #8",
+    "description": "Finds exposed Compliance database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/db-backup-08.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-compliance-09",
+    "name": "Compliance Database Backup Exposure #9",
+    "description": "Finds exposed Compliance database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/db-backup-09.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-compliance-10",
+    "name": "Compliance Database Backup Exposure #10",
+    "description": "Finds exposed Compliance database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/compliance/db-backup-10.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-compliance-06",
+    "name": "Compliance Compliance Report Leak #6",
+    "description": "Detects leaked Compliance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/compliance-report-06.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-compliance-07",
+    "name": "Compliance Compliance Report Leak #7",
+    "description": "Detects leaked Compliance compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/compliance/compliance-report-07.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-compliance-08",
+    "name": "Compliance Compliance Report Leak #8",
+    "description": "Detects leaked Compliance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/compliance-report-08.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-compliance-09",
+    "name": "Compliance Compliance Report Leak #9",
+    "description": "Detects leaked Compliance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/compliance-report-09.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-compliance-10",
+    "name": "Compliance Compliance Report Leak #10",
+    "description": "Detects leaked Compliance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/compliance/compliance-report-10.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "compliance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-customer-success-06",
+    "name": "Customer Success Token Cache Dump #6",
+    "description": "Detects exposed Customer Success token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/token-cache-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-customer-success-07",
+    "name": "Customer Success Token Cache Dump #7",
+    "description": "Detects exposed Customer Success token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/token-cache-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-customer-success-08",
+    "name": "Customer Success Token Cache Dump #8",
+    "description": "Detects exposed Customer Success token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/token-cache-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-customer-success-09",
+    "name": "Customer Success Token Cache Dump #9",
+    "description": "Detects exposed Customer Success token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/token-cache-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-customer-success-10",
+    "name": "Customer Success Token Cache Dump #10",
+    "description": "Detects exposed Customer Success token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/token-cache-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-customer-success-06",
+    "name": "Customer Success Session Ledger Leak #6",
+    "description": "Catches leaked Customer Success session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/sessions-ledger-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-customer-success-07",
+    "name": "Customer Success Session Ledger Leak #7",
+    "description": "Catches leaked Customer Success session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/sessions-ledger-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-customer-success-08",
+    "name": "Customer Success Session Ledger Leak #8",
+    "description": "Catches leaked Customer Success session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/sessions-ledger-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-customer-success-09",
+    "name": "Customer Success Session Ledger Leak #9",
+    "description": "Catches leaked Customer Success session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/sessions-ledger-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-customer-success-10",
+    "name": "Customer Success Session Ledger Leak #10",
+    "description": "Catches leaked Customer Success session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/sessions-ledger-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-customer-success-06",
+    "name": "Customer Success Config Export Exposure #6",
+    "description": "Finds world-readable Customer Success configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/config-export-06.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-customer-success-07",
+    "name": "Customer Success Config Export Exposure #7",
+    "description": "Finds world-readable Customer Success configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/config-export-07.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-customer-success-08",
+    "name": "Customer Success Config Export Exposure #8",
+    "description": "Finds world-readable Customer Success configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/config-export-08.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-customer-success-09",
+    "name": "Customer Success Config Export Exposure #9",
+    "description": "Finds world-readable Customer Success configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/config-export-09.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-customer-success-10",
+    "name": "Customer Success Config Export Exposure #10",
+    "description": "Finds world-readable Customer Success configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/config-export-10.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-customer-success-06",
+    "name": "Customer Success User Dump Exposure #6",
+    "description": "Detects exposed Customer Success user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/user-dump-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-customer-success-07",
+    "name": "Customer Success User Dump Exposure #7",
+    "description": "Detects exposed Customer Success user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/customer-success/user-dump-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-customer-success-08",
+    "name": "Customer Success User Dump Exposure #8",
+    "description": "Detects exposed Customer Success user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/user-dump-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-customer-success-09",
+    "name": "Customer Success User Dump Exposure #9",
+    "description": "Detects exposed Customer Success user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/user-dump-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-customer-success-10",
+    "name": "Customer Success User Dump Exposure #10",
+    "description": "Detects exposed Customer Success user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/user-dump-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-customer-success-06",
+    "name": "Customer Success Billing Export Exposure #6",
+    "description": "Identifies Customer Success billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/billing-export-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-customer-success-07",
+    "name": "Customer Success Billing Export Exposure #7",
+    "description": "Identifies Customer Success billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/customer-success/billing-export-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-customer-success-08",
+    "name": "Customer Success Billing Export Exposure #8",
+    "description": "Identifies Customer Success billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/billing-export-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-customer-success-09",
+    "name": "Customer Success Billing Export Exposure #9",
+    "description": "Identifies Customer Success billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/billing-export-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-customer-success-10",
+    "name": "Customer Success Billing Export Exposure #10",
+    "description": "Identifies Customer Success billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/billing-export-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-customer-success-06",
+    "name": "Customer Success Webhook Registry Leak #6",
+    "description": "Detects leaked Customer Success webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/webhooks-registry-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-customer-success-07",
+    "name": "Customer Success Webhook Registry Leak #7",
+    "description": "Detects leaked Customer Success webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/webhooks-registry-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-customer-success-08",
+    "name": "Customer Success Webhook Registry Leak #8",
+    "description": "Detects leaked Customer Success webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/webhooks-registry-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-customer-success-09",
+    "name": "Customer Success Webhook Registry Leak #9",
+    "description": "Detects leaked Customer Success webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/webhooks-registry-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-customer-success-10",
+    "name": "Customer Success Webhook Registry Leak #10",
+    "description": "Detects leaked Customer Success webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/webhooks-registry-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-customer-success-06",
+    "name": "Customer Success Telemetry Snapshot Exposure #6",
+    "description": "Surfaces exposed Customer Success telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/telemetry-snapshot-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-customer-success-07",
+    "name": "Customer Success Telemetry Snapshot Exposure #7",
+    "description": "Surfaces exposed Customer Success telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/customer-success/telemetry-snapshot-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-customer-success-08",
+    "name": "Customer Success Telemetry Snapshot Exposure #8",
+    "description": "Surfaces exposed Customer Success telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/telemetry-snapshot-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-customer-success-09",
+    "name": "Customer Success Telemetry Snapshot Exposure #9",
+    "description": "Surfaces exposed Customer Success telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/telemetry-snapshot-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-customer-success-10",
+    "name": "Customer Success Telemetry Snapshot Exposure #10",
+    "description": "Surfaces exposed Customer Success telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/telemetry-snapshot-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-customer-success-06",
+    "name": "Customer Success Debug Trace Log Leak #6",
+    "description": "Detects leaked Customer Success debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/debug-trace-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-customer-success-07",
+    "name": "Customer Success Debug Trace Log Leak #7",
+    "description": "Detects leaked Customer Success debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/customer-success/debug-trace-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-customer-success-08",
+    "name": "Customer Success Debug Trace Log Leak #8",
+    "description": "Detects leaked Customer Success debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/debug-trace-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-customer-success-09",
+    "name": "Customer Success Debug Trace Log Leak #9",
+    "description": "Detects leaked Customer Success debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/debug-trace-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-customer-success-10",
+    "name": "Customer Success Debug Trace Log Leak #10",
+    "description": "Detects leaked Customer Success debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/debug-trace-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-customer-success-06",
+    "name": "Customer Success Database Backup Exposure #6",
+    "description": "Finds exposed Customer Success database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/db-backup-06.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-customer-success-07",
+    "name": "Customer Success Database Backup Exposure #7",
+    "description": "Finds exposed Customer Success database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/db-backup-07.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-customer-success-08",
+    "name": "Customer Success Database Backup Exposure #8",
+    "description": "Finds exposed Customer Success database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/db-backup-08.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-customer-success-09",
+    "name": "Customer Success Database Backup Exposure #9",
+    "description": "Finds exposed Customer Success database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/db-backup-09.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-customer-success-10",
+    "name": "Customer Success Database Backup Exposure #10",
+    "description": "Finds exposed Customer Success database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/customer-success/db-backup-10.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-customer-success-06",
+    "name": "Customer Success Compliance Report Leak #6",
+    "description": "Detects leaked Customer Success compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/compliance-report-06.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-customer-success-07",
+    "name": "Customer Success Compliance Report Leak #7",
+    "description": "Detects leaked Customer Success compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/customer-success/compliance-report-07.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-customer-success-08",
+    "name": "Customer Success Compliance Report Leak #8",
+    "description": "Detects leaked Customer Success compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/compliance-report-08.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-customer-success-09",
+    "name": "Customer Success Compliance Report Leak #9",
+    "description": "Detects leaked Customer Success compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/compliance-report-09.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-customer-success-10",
+    "name": "Customer Success Compliance Report Leak #10",
+    "description": "Detects leaked Customer Success compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/customer-success/compliance-report-10.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "customer-success"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-devops-06",
+    "name": "Devops Token Cache Dump #6",
+    "description": "Detects exposed Devops token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/token-cache-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-devops-07",
+    "name": "Devops Token Cache Dump #7",
+    "description": "Detects exposed Devops token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/token-cache-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-devops-08",
+    "name": "Devops Token Cache Dump #8",
+    "description": "Detects exposed Devops token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/token-cache-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-devops-09",
+    "name": "Devops Token Cache Dump #9",
+    "description": "Detects exposed Devops token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/token-cache-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-devops-10",
+    "name": "Devops Token Cache Dump #10",
+    "description": "Detects exposed Devops token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/token-cache-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-devops-06",
+    "name": "Devops Session Ledger Leak #6",
+    "description": "Catches leaked Devops session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/sessions-ledger-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-devops-07",
+    "name": "Devops Session Ledger Leak #7",
+    "description": "Catches leaked Devops session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/sessions-ledger-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-devops-08",
+    "name": "Devops Session Ledger Leak #8",
+    "description": "Catches leaked Devops session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/sessions-ledger-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-devops-09",
+    "name": "Devops Session Ledger Leak #9",
+    "description": "Catches leaked Devops session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/sessions-ledger-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-devops-10",
+    "name": "Devops Session Ledger Leak #10",
+    "description": "Catches leaked Devops session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/sessions-ledger-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-devops-06",
+    "name": "Devops Config Export Exposure #6",
+    "description": "Finds world-readable Devops configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/config-export-06.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-devops-07",
+    "name": "Devops Config Export Exposure #7",
+    "description": "Finds world-readable Devops configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/config-export-07.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-devops-08",
+    "name": "Devops Config Export Exposure #8",
+    "description": "Finds world-readable Devops configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/config-export-08.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-devops-09",
+    "name": "Devops Config Export Exposure #9",
+    "description": "Finds world-readable Devops configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/config-export-09.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-devops-10",
+    "name": "Devops Config Export Exposure #10",
+    "description": "Finds world-readable Devops configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/config-export-10.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-devops-06",
+    "name": "Devops User Dump Exposure #6",
+    "description": "Detects exposed Devops user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/user-dump-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-devops-07",
+    "name": "Devops User Dump Exposure #7",
+    "description": "Detects exposed Devops user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/devops/user-dump-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-devops-08",
+    "name": "Devops User Dump Exposure #8",
+    "description": "Detects exposed Devops user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/user-dump-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-devops-09",
+    "name": "Devops User Dump Exposure #9",
+    "description": "Detects exposed Devops user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/user-dump-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-devops-10",
+    "name": "Devops User Dump Exposure #10",
+    "description": "Detects exposed Devops user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/user-dump-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-devops-06",
+    "name": "Devops Billing Export Exposure #6",
+    "description": "Identifies Devops billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/billing-export-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-devops-07",
+    "name": "Devops Billing Export Exposure #7",
+    "description": "Identifies Devops billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/devops/billing-export-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-devops-08",
+    "name": "Devops Billing Export Exposure #8",
+    "description": "Identifies Devops billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/billing-export-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-devops-09",
+    "name": "Devops Billing Export Exposure #9",
+    "description": "Identifies Devops billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/billing-export-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-devops-10",
+    "name": "Devops Billing Export Exposure #10",
+    "description": "Identifies Devops billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/billing-export-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-devops-06",
+    "name": "Devops Webhook Registry Leak #6",
+    "description": "Detects leaked Devops webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/webhooks-registry-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-devops-07",
+    "name": "Devops Webhook Registry Leak #7",
+    "description": "Detects leaked Devops webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/webhooks-registry-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-devops-08",
+    "name": "Devops Webhook Registry Leak #8",
+    "description": "Detects leaked Devops webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/webhooks-registry-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-devops-09",
+    "name": "Devops Webhook Registry Leak #9",
+    "description": "Detects leaked Devops webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/webhooks-registry-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-devops-10",
+    "name": "Devops Webhook Registry Leak #10",
+    "description": "Detects leaked Devops webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/webhooks-registry-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-devops-06",
+    "name": "Devops Telemetry Snapshot Exposure #6",
+    "description": "Surfaces exposed Devops telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/telemetry-snapshot-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-devops-07",
+    "name": "Devops Telemetry Snapshot Exposure #7",
+    "description": "Surfaces exposed Devops telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/devops/telemetry-snapshot-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-devops-08",
+    "name": "Devops Telemetry Snapshot Exposure #8",
+    "description": "Surfaces exposed Devops telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/telemetry-snapshot-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-devops-09",
+    "name": "Devops Telemetry Snapshot Exposure #9",
+    "description": "Surfaces exposed Devops telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/telemetry-snapshot-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-devops-10",
+    "name": "Devops Telemetry Snapshot Exposure #10",
+    "description": "Surfaces exposed Devops telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/telemetry-snapshot-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-devops-06",
+    "name": "Devops Debug Trace Log Leak #6",
+    "description": "Detects leaked Devops debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/debug-trace-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-devops-07",
+    "name": "Devops Debug Trace Log Leak #7",
+    "description": "Detects leaked Devops debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/devops/debug-trace-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-devops-08",
+    "name": "Devops Debug Trace Log Leak #8",
+    "description": "Detects leaked Devops debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/debug-trace-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-devops-09",
+    "name": "Devops Debug Trace Log Leak #9",
+    "description": "Detects leaked Devops debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/debug-trace-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-devops-10",
+    "name": "Devops Debug Trace Log Leak #10",
+    "description": "Detects leaked Devops debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/debug-trace-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-devops-06",
+    "name": "Devops Database Backup Exposure #6",
+    "description": "Finds exposed Devops database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/db-backup-06.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-devops-07",
+    "name": "Devops Database Backup Exposure #7",
+    "description": "Finds exposed Devops database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/db-backup-07.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-devops-08",
+    "name": "Devops Database Backup Exposure #8",
+    "description": "Finds exposed Devops database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/db-backup-08.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-devops-09",
+    "name": "Devops Database Backup Exposure #9",
+    "description": "Finds exposed Devops database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/db-backup-09.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-devops-10",
+    "name": "Devops Database Backup Exposure #10",
+    "description": "Finds exposed Devops database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/devops/db-backup-10.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-devops-06",
+    "name": "Devops Compliance Report Leak #6",
+    "description": "Detects leaked Devops compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/compliance-report-06.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-devops-07",
+    "name": "Devops Compliance Report Leak #7",
+    "description": "Detects leaked Devops compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/devops/compliance-report-07.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-devops-08",
+    "name": "Devops Compliance Report Leak #8",
+    "description": "Detects leaked Devops compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/compliance-report-08.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-devops-09",
+    "name": "Devops Compliance Report Leak #9",
+    "description": "Detects leaked Devops compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/compliance-report-09.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-devops-10",
+    "name": "Devops Compliance Report Leak #10",
+    "description": "Detects leaked Devops compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/devops/compliance-report-10.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "devops"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-finance-06",
+    "name": "Finance Token Cache Dump #6",
+    "description": "Detects exposed Finance token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/token-cache-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-finance-07",
+    "name": "Finance Token Cache Dump #7",
+    "description": "Detects exposed Finance token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/token-cache-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-finance-08",
+    "name": "Finance Token Cache Dump #8",
+    "description": "Detects exposed Finance token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/token-cache-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-finance-09",
+    "name": "Finance Token Cache Dump #9",
+    "description": "Detects exposed Finance token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/token-cache-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-finance-10",
+    "name": "Finance Token Cache Dump #10",
+    "description": "Detects exposed Finance token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/token-cache-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-finance-06",
+    "name": "Finance Session Ledger Leak #6",
+    "description": "Catches leaked Finance session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/sessions-ledger-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-finance-07",
+    "name": "Finance Session Ledger Leak #7",
+    "description": "Catches leaked Finance session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/sessions-ledger-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-finance-08",
+    "name": "Finance Session Ledger Leak #8",
+    "description": "Catches leaked Finance session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/sessions-ledger-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-finance-09",
+    "name": "Finance Session Ledger Leak #9",
+    "description": "Catches leaked Finance session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/sessions-ledger-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-finance-10",
+    "name": "Finance Session Ledger Leak #10",
+    "description": "Catches leaked Finance session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/sessions-ledger-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-finance-06",
+    "name": "Finance Config Export Exposure #6",
+    "description": "Finds world-readable Finance configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/config-export-06.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-finance-07",
+    "name": "Finance Config Export Exposure #7",
+    "description": "Finds world-readable Finance configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/config-export-07.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-finance-08",
+    "name": "Finance Config Export Exposure #8",
+    "description": "Finds world-readable Finance configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/config-export-08.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-finance-09",
+    "name": "Finance Config Export Exposure #9",
+    "description": "Finds world-readable Finance configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/config-export-09.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-finance-10",
+    "name": "Finance Config Export Exposure #10",
+    "description": "Finds world-readable Finance configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/config-export-10.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-finance-06",
+    "name": "Finance User Dump Exposure #6",
+    "description": "Detects exposed Finance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/user-dump-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-finance-07",
+    "name": "Finance User Dump Exposure #7",
+    "description": "Detects exposed Finance user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/finance/user-dump-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-finance-08",
+    "name": "Finance User Dump Exposure #8",
+    "description": "Detects exposed Finance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/user-dump-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-finance-09",
+    "name": "Finance User Dump Exposure #9",
+    "description": "Detects exposed Finance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/user-dump-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-finance-10",
+    "name": "Finance User Dump Exposure #10",
+    "description": "Detects exposed Finance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/user-dump-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-finance-06",
+    "name": "Finance Billing Export Exposure #6",
+    "description": "Identifies Finance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/billing-export-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-finance-07",
+    "name": "Finance Billing Export Exposure #7",
+    "description": "Identifies Finance billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/finance/billing-export-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-finance-08",
+    "name": "Finance Billing Export Exposure #8",
+    "description": "Identifies Finance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/billing-export-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-finance-09",
+    "name": "Finance Billing Export Exposure #9",
+    "description": "Identifies Finance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/billing-export-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-finance-10",
+    "name": "Finance Billing Export Exposure #10",
+    "description": "Identifies Finance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/billing-export-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-finance-06",
+    "name": "Finance Webhook Registry Leak #6",
+    "description": "Detects leaked Finance webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/webhooks-registry-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-finance-07",
+    "name": "Finance Webhook Registry Leak #7",
+    "description": "Detects leaked Finance webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/webhooks-registry-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-finance-08",
+    "name": "Finance Webhook Registry Leak #8",
+    "description": "Detects leaked Finance webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/webhooks-registry-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-finance-09",
+    "name": "Finance Webhook Registry Leak #9",
+    "description": "Detects leaked Finance webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/webhooks-registry-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-finance-10",
+    "name": "Finance Webhook Registry Leak #10",
+    "description": "Detects leaked Finance webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/webhooks-registry-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-finance-06",
+    "name": "Finance Telemetry Snapshot Exposure #6",
+    "description": "Surfaces exposed Finance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/telemetry-snapshot-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-finance-07",
+    "name": "Finance Telemetry Snapshot Exposure #7",
+    "description": "Surfaces exposed Finance telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/finance/telemetry-snapshot-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-finance-08",
+    "name": "Finance Telemetry Snapshot Exposure #8",
+    "description": "Surfaces exposed Finance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/telemetry-snapshot-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-finance-09",
+    "name": "Finance Telemetry Snapshot Exposure #9",
+    "description": "Surfaces exposed Finance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/telemetry-snapshot-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-finance-10",
+    "name": "Finance Telemetry Snapshot Exposure #10",
+    "description": "Surfaces exposed Finance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/telemetry-snapshot-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-finance-06",
+    "name": "Finance Debug Trace Log Leak #6",
+    "description": "Detects leaked Finance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/debug-trace-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-finance-07",
+    "name": "Finance Debug Trace Log Leak #7",
+    "description": "Detects leaked Finance debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/finance/debug-trace-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-finance-08",
+    "name": "Finance Debug Trace Log Leak #8",
+    "description": "Detects leaked Finance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/debug-trace-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-finance-09",
+    "name": "Finance Debug Trace Log Leak #9",
+    "description": "Detects leaked Finance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/debug-trace-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-finance-10",
+    "name": "Finance Debug Trace Log Leak #10",
+    "description": "Detects leaked Finance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/debug-trace-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-finance-06",
+    "name": "Finance Database Backup Exposure #6",
+    "description": "Finds exposed Finance database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/db-backup-06.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-finance-07",
+    "name": "Finance Database Backup Exposure #7",
+    "description": "Finds exposed Finance database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/db-backup-07.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-finance-08",
+    "name": "Finance Database Backup Exposure #8",
+    "description": "Finds exposed Finance database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/db-backup-08.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-finance-09",
+    "name": "Finance Database Backup Exposure #9",
+    "description": "Finds exposed Finance database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/db-backup-09.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-finance-10",
+    "name": "Finance Database Backup Exposure #10",
+    "description": "Finds exposed Finance database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/finance/db-backup-10.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-finance-06",
+    "name": "Finance Compliance Report Leak #6",
+    "description": "Detects leaked Finance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/compliance-report-06.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-finance-07",
+    "name": "Finance Compliance Report Leak #7",
+    "description": "Detects leaked Finance compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/finance/compliance-report-07.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-finance-08",
+    "name": "Finance Compliance Report Leak #8",
+    "description": "Detects leaked Finance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/compliance-report-08.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-finance-09",
+    "name": "Finance Compliance Report Leak #9",
+    "description": "Detects leaked Finance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/compliance-report-09.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-finance-10",
+    "name": "Finance Compliance Report Leak #10",
+    "description": "Detects leaked Finance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/finance/compliance-report-10.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "finance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-governance-06",
+    "name": "Governance Token Cache Dump #6",
+    "description": "Detects exposed Governance token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/token-cache-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-governance-07",
+    "name": "Governance Token Cache Dump #7",
+    "description": "Detects exposed Governance token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/token-cache-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-governance-08",
+    "name": "Governance Token Cache Dump #8",
+    "description": "Detects exposed Governance token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/token-cache-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-governance-09",
+    "name": "Governance Token Cache Dump #9",
+    "description": "Detects exposed Governance token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/token-cache-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-governance-10",
+    "name": "Governance Token Cache Dump #10",
+    "description": "Detects exposed Governance token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/token-cache-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-governance-06",
+    "name": "Governance Session Ledger Leak #6",
+    "description": "Catches leaked Governance session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/sessions-ledger-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-governance-07",
+    "name": "Governance Session Ledger Leak #7",
+    "description": "Catches leaked Governance session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/sessions-ledger-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-governance-08",
+    "name": "Governance Session Ledger Leak #8",
+    "description": "Catches leaked Governance session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/sessions-ledger-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-governance-09",
+    "name": "Governance Session Ledger Leak #9",
+    "description": "Catches leaked Governance session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/sessions-ledger-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-governance-10",
+    "name": "Governance Session Ledger Leak #10",
+    "description": "Catches leaked Governance session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/sessions-ledger-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-governance-06",
+    "name": "Governance Config Export Exposure #6",
+    "description": "Finds world-readable Governance configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/config-export-06.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-governance-07",
+    "name": "Governance Config Export Exposure #7",
+    "description": "Finds world-readable Governance configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/config-export-07.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-governance-08",
+    "name": "Governance Config Export Exposure #8",
+    "description": "Finds world-readable Governance configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/config-export-08.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-governance-09",
+    "name": "Governance Config Export Exposure #9",
+    "description": "Finds world-readable Governance configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/config-export-09.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-governance-10",
+    "name": "Governance Config Export Exposure #10",
+    "description": "Finds world-readable Governance configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/config-export-10.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-governance-06",
+    "name": "Governance User Dump Exposure #6",
+    "description": "Detects exposed Governance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/user-dump-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-governance-07",
+    "name": "Governance User Dump Exposure #7",
+    "description": "Detects exposed Governance user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/governance/user-dump-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-governance-08",
+    "name": "Governance User Dump Exposure #8",
+    "description": "Detects exposed Governance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/user-dump-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-governance-09",
+    "name": "Governance User Dump Exposure #9",
+    "description": "Detects exposed Governance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/user-dump-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-governance-10",
+    "name": "Governance User Dump Exposure #10",
+    "description": "Detects exposed Governance user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/user-dump-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-governance-06",
+    "name": "Governance Billing Export Exposure #6",
+    "description": "Identifies Governance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/billing-export-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-governance-07",
+    "name": "Governance Billing Export Exposure #7",
+    "description": "Identifies Governance billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/governance/billing-export-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-governance-08",
+    "name": "Governance Billing Export Exposure #8",
+    "description": "Identifies Governance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/billing-export-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-governance-09",
+    "name": "Governance Billing Export Exposure #9",
+    "description": "Identifies Governance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/billing-export-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-governance-10",
+    "name": "Governance Billing Export Exposure #10",
+    "description": "Identifies Governance billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/billing-export-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-governance-06",
+    "name": "Governance Webhook Registry Leak #6",
+    "description": "Detects leaked Governance webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/webhooks-registry-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-governance-07",
+    "name": "Governance Webhook Registry Leak #7",
+    "description": "Detects leaked Governance webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/webhooks-registry-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-governance-08",
+    "name": "Governance Webhook Registry Leak #8",
+    "description": "Detects leaked Governance webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/webhooks-registry-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-governance-09",
+    "name": "Governance Webhook Registry Leak #9",
+    "description": "Detects leaked Governance webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/webhooks-registry-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-governance-10",
+    "name": "Governance Webhook Registry Leak #10",
+    "description": "Detects leaked Governance webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/webhooks-registry-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-governance-06",
+    "name": "Governance Telemetry Snapshot Exposure #6",
+    "description": "Surfaces exposed Governance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/telemetry-snapshot-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-governance-07",
+    "name": "Governance Telemetry Snapshot Exposure #7",
+    "description": "Surfaces exposed Governance telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/governance/telemetry-snapshot-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-governance-08",
+    "name": "Governance Telemetry Snapshot Exposure #8",
+    "description": "Surfaces exposed Governance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/telemetry-snapshot-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-governance-09",
+    "name": "Governance Telemetry Snapshot Exposure #9",
+    "description": "Surfaces exposed Governance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/telemetry-snapshot-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-governance-10",
+    "name": "Governance Telemetry Snapshot Exposure #10",
+    "description": "Surfaces exposed Governance telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/telemetry-snapshot-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-governance-06",
+    "name": "Governance Debug Trace Log Leak #6",
+    "description": "Detects leaked Governance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/debug-trace-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-governance-07",
+    "name": "Governance Debug Trace Log Leak #7",
+    "description": "Detects leaked Governance debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/governance/debug-trace-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-governance-08",
+    "name": "Governance Debug Trace Log Leak #8",
+    "description": "Detects leaked Governance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/debug-trace-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-governance-09",
+    "name": "Governance Debug Trace Log Leak #9",
+    "description": "Detects leaked Governance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/debug-trace-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-governance-10",
+    "name": "Governance Debug Trace Log Leak #10",
+    "description": "Detects leaked Governance debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/debug-trace-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-governance-06",
+    "name": "Governance Database Backup Exposure #6",
+    "description": "Finds exposed Governance database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/db-backup-06.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-governance-07",
+    "name": "Governance Database Backup Exposure #7",
+    "description": "Finds exposed Governance database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/db-backup-07.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-governance-08",
+    "name": "Governance Database Backup Exposure #8",
+    "description": "Finds exposed Governance database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/db-backup-08.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-governance-09",
+    "name": "Governance Database Backup Exposure #9",
+    "description": "Finds exposed Governance database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/db-backup-09.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-governance-10",
+    "name": "Governance Database Backup Exposure #10",
+    "description": "Finds exposed Governance database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/governance/db-backup-10.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-governance-06",
+    "name": "Governance Compliance Report Leak #6",
+    "description": "Detects leaked Governance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/compliance-report-06.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-governance-07",
+    "name": "Governance Compliance Report Leak #7",
+    "description": "Detects leaked Governance compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/governance/compliance-report-07.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-governance-08",
+    "name": "Governance Compliance Report Leak #8",
+    "description": "Detects leaked Governance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/compliance-report-08.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-governance-09",
+    "name": "Governance Compliance Report Leak #9",
+    "description": "Detects leaked Governance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/compliance-report-09.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-governance-10",
+    "name": "Governance Compliance Report Leak #10",
+    "description": "Detects leaked Governance compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/governance/compliance-report-10.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "governance"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-identity-06",
+    "name": "Identity Token Cache Dump #6",
+    "description": "Detects exposed Identity token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/token-cache-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-identity-07",
+    "name": "Identity Token Cache Dump #7",
+    "description": "Detects exposed Identity token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/token-cache-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-identity-08",
+    "name": "Identity Token Cache Dump #8",
+    "description": "Detects exposed Identity token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/token-cache-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-identity-09",
+    "name": "Identity Token Cache Dump #9",
+    "description": "Detects exposed Identity token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/token-cache-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-identity-10",
+    "name": "Identity Token Cache Dump #10",
+    "description": "Detects exposed Identity token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/token-cache-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-identity-06",
+    "name": "Identity Session Ledger Leak #6",
+    "description": "Catches leaked Identity session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/sessions-ledger-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-identity-07",
+    "name": "Identity Session Ledger Leak #7",
+    "description": "Catches leaked Identity session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/sessions-ledger-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-identity-08",
+    "name": "Identity Session Ledger Leak #8",
+    "description": "Catches leaked Identity session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/sessions-ledger-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-identity-09",
+    "name": "Identity Session Ledger Leak #9",
+    "description": "Catches leaked Identity session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/sessions-ledger-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-identity-10",
+    "name": "Identity Session Ledger Leak #10",
+    "description": "Catches leaked Identity session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/sessions-ledger-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-identity-06",
+    "name": "Identity Config Export Exposure #6",
+    "description": "Finds world-readable Identity configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/config-export-06.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-identity-07",
+    "name": "Identity Config Export Exposure #7",
+    "description": "Finds world-readable Identity configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/config-export-07.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-identity-08",
+    "name": "Identity Config Export Exposure #8",
+    "description": "Finds world-readable Identity configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/config-export-08.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-identity-09",
+    "name": "Identity Config Export Exposure #9",
+    "description": "Finds world-readable Identity configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/config-export-09.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-identity-10",
+    "name": "Identity Config Export Exposure #10",
+    "description": "Finds world-readable Identity configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/config-export-10.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-identity-06",
+    "name": "Identity User Dump Exposure #6",
+    "description": "Detects exposed Identity user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/user-dump-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-identity-07",
+    "name": "Identity User Dump Exposure #7",
+    "description": "Detects exposed Identity user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/identity/user-dump-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-identity-08",
+    "name": "Identity User Dump Exposure #8",
+    "description": "Detects exposed Identity user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/user-dump-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-identity-09",
+    "name": "Identity User Dump Exposure #9",
+    "description": "Detects exposed Identity user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/user-dump-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-identity-10",
+    "name": "Identity User Dump Exposure #10",
+    "description": "Detects exposed Identity user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/user-dump-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-identity-06",
+    "name": "Identity Billing Export Exposure #6",
+    "description": "Identifies Identity billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/billing-export-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-identity-07",
+    "name": "Identity Billing Export Exposure #7",
+    "description": "Identifies Identity billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/identity/billing-export-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-identity-08",
+    "name": "Identity Billing Export Exposure #8",
+    "description": "Identifies Identity billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/billing-export-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-identity-09",
+    "name": "Identity Billing Export Exposure #9",
+    "description": "Identifies Identity billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/billing-export-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-identity-10",
+    "name": "Identity Billing Export Exposure #10",
+    "description": "Identifies Identity billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/billing-export-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-identity-06",
+    "name": "Identity Webhook Registry Leak #6",
+    "description": "Detects leaked Identity webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/webhooks-registry-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-identity-07",
+    "name": "Identity Webhook Registry Leak #7",
+    "description": "Detects leaked Identity webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/webhooks-registry-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-identity-08",
+    "name": "Identity Webhook Registry Leak #8",
+    "description": "Detects leaked Identity webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/webhooks-registry-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-identity-09",
+    "name": "Identity Webhook Registry Leak #9",
+    "description": "Detects leaked Identity webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/webhooks-registry-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-identity-10",
+    "name": "Identity Webhook Registry Leak #10",
+    "description": "Detects leaked Identity webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/webhooks-registry-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-identity-06",
+    "name": "Identity Telemetry Snapshot Exposure #6",
+    "description": "Surfaces exposed Identity telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/telemetry-snapshot-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-identity-07",
+    "name": "Identity Telemetry Snapshot Exposure #7",
+    "description": "Surfaces exposed Identity telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/identity/telemetry-snapshot-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-identity-08",
+    "name": "Identity Telemetry Snapshot Exposure #8",
+    "description": "Surfaces exposed Identity telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/telemetry-snapshot-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-identity-09",
+    "name": "Identity Telemetry Snapshot Exposure #9",
+    "description": "Surfaces exposed Identity telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/telemetry-snapshot-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-identity-10",
+    "name": "Identity Telemetry Snapshot Exposure #10",
+    "description": "Surfaces exposed Identity telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/telemetry-snapshot-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-identity-06",
+    "name": "Identity Debug Trace Log Leak #6",
+    "description": "Detects leaked Identity debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/debug-trace-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-identity-07",
+    "name": "Identity Debug Trace Log Leak #7",
+    "description": "Detects leaked Identity debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/identity/debug-trace-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-identity-08",
+    "name": "Identity Debug Trace Log Leak #8",
+    "description": "Detects leaked Identity debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/debug-trace-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-identity-09",
+    "name": "Identity Debug Trace Log Leak #9",
+    "description": "Detects leaked Identity debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/debug-trace-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-identity-10",
+    "name": "Identity Debug Trace Log Leak #10",
+    "description": "Detects leaked Identity debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/debug-trace-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-identity-06",
+    "name": "Identity Database Backup Exposure #6",
+    "description": "Finds exposed Identity database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/db-backup-06.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-identity-07",
+    "name": "Identity Database Backup Exposure #7",
+    "description": "Finds exposed Identity database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/db-backup-07.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-identity-08",
+    "name": "Identity Database Backup Exposure #8",
+    "description": "Finds exposed Identity database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/db-backup-08.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-identity-09",
+    "name": "Identity Database Backup Exposure #9",
+    "description": "Finds exposed Identity database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/db-backup-09.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-identity-10",
+    "name": "Identity Database Backup Exposure #10",
+    "description": "Finds exposed Identity database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/identity/db-backup-10.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-identity-06",
+    "name": "Identity Compliance Report Leak #6",
+    "description": "Detects leaked Identity compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/compliance-report-06.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-identity-07",
+    "name": "Identity Compliance Report Leak #7",
+    "description": "Detects leaked Identity compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/identity/compliance-report-07.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-identity-08",
+    "name": "Identity Compliance Report Leak #8",
+    "description": "Detects leaked Identity compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/compliance-report-08.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-identity-09",
+    "name": "Identity Compliance Report Leak #9",
+    "description": "Detects leaked Identity compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/compliance-report-09.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-identity-10",
+    "name": "Identity Compliance Report Leak #10",
+    "description": "Detects leaked Identity compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/identity/compliance-report-10.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "identity"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-infrastructure-06",
+    "name": "Infrastructure Token Cache Dump #6",
+    "description": "Detects exposed Infrastructure token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/token-cache-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-infrastructure-07",
+    "name": "Infrastructure Token Cache Dump #7",
+    "description": "Detects exposed Infrastructure token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/token-cache-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-infrastructure-08",
+    "name": "Infrastructure Token Cache Dump #8",
+    "description": "Detects exposed Infrastructure token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/token-cache-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-infrastructure-09",
+    "name": "Infrastructure Token Cache Dump #9",
+    "description": "Detects exposed Infrastructure token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/token-cache-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-infrastructure-10",
+    "name": "Infrastructure Token Cache Dump #10",
+    "description": "Detects exposed Infrastructure token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/token-cache-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-infrastructure-06",
+    "name": "Infrastructure Session Ledger Leak #6",
+    "description": "Catches leaked Infrastructure session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/sessions-ledger-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-infrastructure-07",
+    "name": "Infrastructure Session Ledger Leak #7",
+    "description": "Catches leaked Infrastructure session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/sessions-ledger-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-infrastructure-08",
+    "name": "Infrastructure Session Ledger Leak #8",
+    "description": "Catches leaked Infrastructure session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/sessions-ledger-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-infrastructure-09",
+    "name": "Infrastructure Session Ledger Leak #9",
+    "description": "Catches leaked Infrastructure session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/sessions-ledger-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-infrastructure-10",
+    "name": "Infrastructure Session Ledger Leak #10",
+    "description": "Catches leaked Infrastructure session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/sessions-ledger-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-infrastructure-06",
+    "name": "Infrastructure Config Export Exposure #6",
+    "description": "Finds world-readable Infrastructure configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/config-export-06.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-infrastructure-07",
+    "name": "Infrastructure Config Export Exposure #7",
+    "description": "Finds world-readable Infrastructure configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/config-export-07.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-infrastructure-08",
+    "name": "Infrastructure Config Export Exposure #8",
+    "description": "Finds world-readable Infrastructure configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/config-export-08.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-infrastructure-09",
+    "name": "Infrastructure Config Export Exposure #9",
+    "description": "Finds world-readable Infrastructure configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/config-export-09.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-infrastructure-10",
+    "name": "Infrastructure Config Export Exposure #10",
+    "description": "Finds world-readable Infrastructure configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/config-export-10.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-infrastructure-06",
+    "name": "Infrastructure User Dump Exposure #6",
+    "description": "Detects exposed Infrastructure user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/user-dump-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-infrastructure-07",
+    "name": "Infrastructure User Dump Exposure #7",
+    "description": "Detects exposed Infrastructure user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/infrastructure/user-dump-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-infrastructure-08",
+    "name": "Infrastructure User Dump Exposure #8",
+    "description": "Detects exposed Infrastructure user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/user-dump-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-infrastructure-09",
+    "name": "Infrastructure User Dump Exposure #9",
+    "description": "Detects exposed Infrastructure user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/user-dump-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-infrastructure-10",
+    "name": "Infrastructure User Dump Exposure #10",
+    "description": "Detects exposed Infrastructure user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/user-dump-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-infrastructure-06",
+    "name": "Infrastructure Billing Export Exposure #6",
+    "description": "Identifies Infrastructure billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/billing-export-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-infrastructure-07",
+    "name": "Infrastructure Billing Export Exposure #7",
+    "description": "Identifies Infrastructure billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/infrastructure/billing-export-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-infrastructure-08",
+    "name": "Infrastructure Billing Export Exposure #8",
+    "description": "Identifies Infrastructure billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/billing-export-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-infrastructure-09",
+    "name": "Infrastructure Billing Export Exposure #9",
+    "description": "Identifies Infrastructure billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/billing-export-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-infrastructure-10",
+    "name": "Infrastructure Billing Export Exposure #10",
+    "description": "Identifies Infrastructure billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/billing-export-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-infrastructure-06",
+    "name": "Infrastructure Webhook Registry Leak #6",
+    "description": "Detects leaked Infrastructure webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/webhooks-registry-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-infrastructure-07",
+    "name": "Infrastructure Webhook Registry Leak #7",
+    "description": "Detects leaked Infrastructure webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/webhooks-registry-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-infrastructure-08",
+    "name": "Infrastructure Webhook Registry Leak #8",
+    "description": "Detects leaked Infrastructure webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/webhooks-registry-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-infrastructure-09",
+    "name": "Infrastructure Webhook Registry Leak #9",
+    "description": "Detects leaked Infrastructure webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/webhooks-registry-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-infrastructure-10",
+    "name": "Infrastructure Webhook Registry Leak #10",
+    "description": "Detects leaked Infrastructure webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/webhooks-registry-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-infrastructure-06",
+    "name": "Infrastructure Telemetry Snapshot Exposure #6",
+    "description": "Surfaces exposed Infrastructure telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/telemetry-snapshot-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-infrastructure-07",
+    "name": "Infrastructure Telemetry Snapshot Exposure #7",
+    "description": "Surfaces exposed Infrastructure telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/infrastructure/telemetry-snapshot-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-infrastructure-08",
+    "name": "Infrastructure Telemetry Snapshot Exposure #8",
+    "description": "Surfaces exposed Infrastructure telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/telemetry-snapshot-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-infrastructure-09",
+    "name": "Infrastructure Telemetry Snapshot Exposure #9",
+    "description": "Surfaces exposed Infrastructure telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/telemetry-snapshot-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-infrastructure-10",
+    "name": "Infrastructure Telemetry Snapshot Exposure #10",
+    "description": "Surfaces exposed Infrastructure telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/telemetry-snapshot-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-infrastructure-06",
+    "name": "Infrastructure Debug Trace Log Leak #6",
+    "description": "Detects leaked Infrastructure debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/debug-trace-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-infrastructure-07",
+    "name": "Infrastructure Debug Trace Log Leak #7",
+    "description": "Detects leaked Infrastructure debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/infrastructure/debug-trace-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-infrastructure-08",
+    "name": "Infrastructure Debug Trace Log Leak #8",
+    "description": "Detects leaked Infrastructure debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/debug-trace-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-infrastructure-09",
+    "name": "Infrastructure Debug Trace Log Leak #9",
+    "description": "Detects leaked Infrastructure debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/debug-trace-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-infrastructure-10",
+    "name": "Infrastructure Debug Trace Log Leak #10",
+    "description": "Detects leaked Infrastructure debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/debug-trace-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-infrastructure-06",
+    "name": "Infrastructure Database Backup Exposure #6",
+    "description": "Finds exposed Infrastructure database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/db-backup-06.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-infrastructure-07",
+    "name": "Infrastructure Database Backup Exposure #7",
+    "description": "Finds exposed Infrastructure database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/db-backup-07.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-infrastructure-08",
+    "name": "Infrastructure Database Backup Exposure #8",
+    "description": "Finds exposed Infrastructure database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/db-backup-08.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-infrastructure-09",
+    "name": "Infrastructure Database Backup Exposure #9",
+    "description": "Finds exposed Infrastructure database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/db-backup-09.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-infrastructure-10",
+    "name": "Infrastructure Database Backup Exposure #10",
+    "description": "Finds exposed Infrastructure database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/infrastructure/db-backup-10.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-infrastructure-06",
+    "name": "Infrastructure Compliance Report Leak #6",
+    "description": "Detects leaked Infrastructure compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/compliance-report-06.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-infrastructure-07",
+    "name": "Infrastructure Compliance Report Leak #7",
+    "description": "Detects leaked Infrastructure compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/infrastructure/compliance-report-07.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-infrastructure-08",
+    "name": "Infrastructure Compliance Report Leak #8",
+    "description": "Detects leaked Infrastructure compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/compliance-report-08.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-infrastructure-09",
+    "name": "Infrastructure Compliance Report Leak #9",
+    "description": "Detects leaked Infrastructure compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/compliance-report-09.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-infrastructure-10",
+    "name": "Infrastructure Compliance Report Leak #10",
+    "description": "Detects leaked Infrastructure compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/infrastructure/compliance-report-10.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "infrastructure"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-logistics-06",
+    "name": "Logistics Token Cache Dump #6",
+    "description": "Detects exposed Logistics token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/token-cache-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-logistics-07",
+    "name": "Logistics Token Cache Dump #7",
+    "description": "Detects exposed Logistics token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/token-cache-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-logistics-08",
+    "name": "Logistics Token Cache Dump #8",
+    "description": "Detects exposed Logistics token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/token-cache-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-logistics-09",
+    "name": "Logistics Token Cache Dump #9",
+    "description": "Detects exposed Logistics token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/token-cache-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-logistics-10",
+    "name": "Logistics Token Cache Dump #10",
+    "description": "Detects exposed Logistics token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/token-cache-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-logistics-06",
+    "name": "Logistics Session Ledger Leak #6",
+    "description": "Catches leaked Logistics session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/sessions-ledger-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-logistics-07",
+    "name": "Logistics Session Ledger Leak #7",
+    "description": "Catches leaked Logistics session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/sessions-ledger-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-logistics-08",
+    "name": "Logistics Session Ledger Leak #8",
+    "description": "Catches leaked Logistics session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/sessions-ledger-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-logistics-09",
+    "name": "Logistics Session Ledger Leak #9",
+    "description": "Catches leaked Logistics session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/sessions-ledger-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-logistics-10",
+    "name": "Logistics Session Ledger Leak #10",
+    "description": "Catches leaked Logistics session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/sessions-ledger-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-logistics-06",
+    "name": "Logistics Config Export Exposure #6",
+    "description": "Finds world-readable Logistics configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/config-export-06.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-logistics-07",
+    "name": "Logistics Config Export Exposure #7",
+    "description": "Finds world-readable Logistics configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/config-export-07.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-logistics-08",
+    "name": "Logistics Config Export Exposure #8",
+    "description": "Finds world-readable Logistics configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/config-export-08.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-logistics-09",
+    "name": "Logistics Config Export Exposure #9",
+    "description": "Finds world-readable Logistics configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/config-export-09.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-logistics-10",
+    "name": "Logistics Config Export Exposure #10",
+    "description": "Finds world-readable Logistics configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/config-export-10.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-logistics-06",
+    "name": "Logistics User Dump Exposure #6",
+    "description": "Detects exposed Logistics user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/user-dump-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-logistics-07",
+    "name": "Logistics User Dump Exposure #7",
+    "description": "Detects exposed Logistics user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/logistics/user-dump-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-logistics-08",
+    "name": "Logistics User Dump Exposure #8",
+    "description": "Detects exposed Logistics user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/user-dump-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-logistics-09",
+    "name": "Logistics User Dump Exposure #9",
+    "description": "Detects exposed Logistics user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/user-dump-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-logistics-10",
+    "name": "Logistics User Dump Exposure #10",
+    "description": "Detects exposed Logistics user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/user-dump-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-logistics-06",
+    "name": "Logistics Billing Export Exposure #6",
+    "description": "Identifies Logistics billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/billing-export-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-logistics-07",
+    "name": "Logistics Billing Export Exposure #7",
+    "description": "Identifies Logistics billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/logistics/billing-export-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-logistics-08",
+    "name": "Logistics Billing Export Exposure #8",
+    "description": "Identifies Logistics billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/billing-export-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-logistics-09",
+    "name": "Logistics Billing Export Exposure #9",
+    "description": "Identifies Logistics billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/billing-export-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-logistics-10",
+    "name": "Logistics Billing Export Exposure #10",
+    "description": "Identifies Logistics billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/billing-export-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-logistics-06",
+    "name": "Logistics Webhook Registry Leak #6",
+    "description": "Detects leaked Logistics webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/webhooks-registry-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-logistics-07",
+    "name": "Logistics Webhook Registry Leak #7",
+    "description": "Detects leaked Logistics webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/webhooks-registry-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-logistics-08",
+    "name": "Logistics Webhook Registry Leak #8",
+    "description": "Detects leaked Logistics webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/webhooks-registry-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-logistics-09",
+    "name": "Logistics Webhook Registry Leak #9",
+    "description": "Detects leaked Logistics webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/webhooks-registry-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-logistics-10",
+    "name": "Logistics Webhook Registry Leak #10",
+    "description": "Detects leaked Logistics webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/webhooks-registry-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-logistics-06",
+    "name": "Logistics Telemetry Snapshot Exposure #6",
+    "description": "Surfaces exposed Logistics telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/telemetry-snapshot-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-logistics-07",
+    "name": "Logistics Telemetry Snapshot Exposure #7",
+    "description": "Surfaces exposed Logistics telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/logistics/telemetry-snapshot-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-logistics-08",
+    "name": "Logistics Telemetry Snapshot Exposure #8",
+    "description": "Surfaces exposed Logistics telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/telemetry-snapshot-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-logistics-09",
+    "name": "Logistics Telemetry Snapshot Exposure #9",
+    "description": "Surfaces exposed Logistics telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/telemetry-snapshot-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-logistics-10",
+    "name": "Logistics Telemetry Snapshot Exposure #10",
+    "description": "Surfaces exposed Logistics telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/telemetry-snapshot-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-logistics-06",
+    "name": "Logistics Debug Trace Log Leak #6",
+    "description": "Detects leaked Logistics debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/debug-trace-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-logistics-07",
+    "name": "Logistics Debug Trace Log Leak #7",
+    "description": "Detects leaked Logistics debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/logistics/debug-trace-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-logistics-08",
+    "name": "Logistics Debug Trace Log Leak #8",
+    "description": "Detects leaked Logistics debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/debug-trace-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-logistics-09",
+    "name": "Logistics Debug Trace Log Leak #9",
+    "description": "Detects leaked Logistics debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/debug-trace-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-logistics-10",
+    "name": "Logistics Debug Trace Log Leak #10",
+    "description": "Detects leaked Logistics debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/debug-trace-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-logistics-06",
+    "name": "Logistics Database Backup Exposure #6",
+    "description": "Finds exposed Logistics database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/db-backup-06.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-logistics-07",
+    "name": "Logistics Database Backup Exposure #7",
+    "description": "Finds exposed Logistics database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/db-backup-07.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-logistics-08",
+    "name": "Logistics Database Backup Exposure #8",
+    "description": "Finds exposed Logistics database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/db-backup-08.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-logistics-09",
+    "name": "Logistics Database Backup Exposure #9",
+    "description": "Finds exposed Logistics database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/db-backup-09.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-logistics-10",
+    "name": "Logistics Database Backup Exposure #10",
+    "description": "Finds exposed Logistics database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/logistics/db-backup-10.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-logistics-06",
+    "name": "Logistics Compliance Report Leak #6",
+    "description": "Detects leaked Logistics compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/compliance-report-06.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-logistics-07",
+    "name": "Logistics Compliance Report Leak #7",
+    "description": "Detects leaked Logistics compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/logistics/compliance-report-07.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-logistics-08",
+    "name": "Logistics Compliance Report Leak #8",
+    "description": "Detects leaked Logistics compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/compliance-report-08.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-logistics-09",
+    "name": "Logistics Compliance Report Leak #9",
+    "description": "Detects leaked Logistics compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/compliance-report-09.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-logistics-10",
+    "name": "Logistics Compliance Report Leak #10",
+    "description": "Detects leaked Logistics compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/logistics/compliance-report-10.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "logistics"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-marketing-06",
+    "name": "Marketing Token Cache Dump #6",
+    "description": "Detects exposed Marketing token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/token-cache-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-marketing-07",
+    "name": "Marketing Token Cache Dump #7",
+    "description": "Detects exposed Marketing token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/token-cache-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-marketing-08",
+    "name": "Marketing Token Cache Dump #8",
+    "description": "Detects exposed Marketing token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/token-cache-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-marketing-09",
+    "name": "Marketing Token Cache Dump #9",
+    "description": "Detects exposed Marketing token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/token-cache-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-marketing-10",
+    "name": "Marketing Token Cache Dump #10",
+    "description": "Detects exposed Marketing token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/token-cache-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-marketing-06",
+    "name": "Marketing Session Ledger Leak #6",
+    "description": "Catches leaked Marketing session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/sessions-ledger-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-marketing-07",
+    "name": "Marketing Session Ledger Leak #7",
+    "description": "Catches leaked Marketing session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/sessions-ledger-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-marketing-08",
+    "name": "Marketing Session Ledger Leak #8",
+    "description": "Catches leaked Marketing session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/sessions-ledger-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-marketing-09",
+    "name": "Marketing Session Ledger Leak #9",
+    "description": "Catches leaked Marketing session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/sessions-ledger-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-marketing-10",
+    "name": "Marketing Session Ledger Leak #10",
+    "description": "Catches leaked Marketing session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/sessions-ledger-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-marketing-06",
+    "name": "Marketing Config Export Exposure #6",
+    "description": "Finds world-readable Marketing configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/config-export-06.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-marketing-07",
+    "name": "Marketing Config Export Exposure #7",
+    "description": "Finds world-readable Marketing configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/config-export-07.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-marketing-08",
+    "name": "Marketing Config Export Exposure #8",
+    "description": "Finds world-readable Marketing configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/config-export-08.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-marketing-09",
+    "name": "Marketing Config Export Exposure #9",
+    "description": "Finds world-readable Marketing configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/config-export-09.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-marketing-10",
+    "name": "Marketing Config Export Exposure #10",
+    "description": "Finds world-readable Marketing configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/config-export-10.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-marketing-06",
+    "name": "Marketing User Dump Exposure #6",
+    "description": "Detects exposed Marketing user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/user-dump-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-marketing-07",
+    "name": "Marketing User Dump Exposure #7",
+    "description": "Detects exposed Marketing user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/marketing/user-dump-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-marketing-08",
+    "name": "Marketing User Dump Exposure #8",
+    "description": "Detects exposed Marketing user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/user-dump-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-marketing-09",
+    "name": "Marketing User Dump Exposure #9",
+    "description": "Detects exposed Marketing user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/user-dump-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-marketing-10",
+    "name": "Marketing User Dump Exposure #10",
+    "description": "Detects exposed Marketing user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/user-dump-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-marketing-06",
+    "name": "Marketing Billing Export Exposure #6",
+    "description": "Identifies Marketing billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/billing-export-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-marketing-07",
+    "name": "Marketing Billing Export Exposure #7",
+    "description": "Identifies Marketing billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/marketing/billing-export-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-marketing-08",
+    "name": "Marketing Billing Export Exposure #8",
+    "description": "Identifies Marketing billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/billing-export-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-marketing-09",
+    "name": "Marketing Billing Export Exposure #9",
+    "description": "Identifies Marketing billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/billing-export-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-marketing-10",
+    "name": "Marketing Billing Export Exposure #10",
+    "description": "Identifies Marketing billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/billing-export-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-marketing-06",
+    "name": "Marketing Webhook Registry Leak #6",
+    "description": "Detects leaked Marketing webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/webhooks-registry-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-marketing-07",
+    "name": "Marketing Webhook Registry Leak #7",
+    "description": "Detects leaked Marketing webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/webhooks-registry-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-marketing-08",
+    "name": "Marketing Webhook Registry Leak #8",
+    "description": "Detects leaked Marketing webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/webhooks-registry-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-marketing-09",
+    "name": "Marketing Webhook Registry Leak #9",
+    "description": "Detects leaked Marketing webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/webhooks-registry-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-marketing-10",
+    "name": "Marketing Webhook Registry Leak #10",
+    "description": "Detects leaked Marketing webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/webhooks-registry-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-marketing-06",
+    "name": "Marketing Telemetry Snapshot Exposure #6",
+    "description": "Surfaces exposed Marketing telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/telemetry-snapshot-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-marketing-07",
+    "name": "Marketing Telemetry Snapshot Exposure #7",
+    "description": "Surfaces exposed Marketing telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/marketing/telemetry-snapshot-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-marketing-08",
+    "name": "Marketing Telemetry Snapshot Exposure #8",
+    "description": "Surfaces exposed Marketing telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/telemetry-snapshot-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-marketing-09",
+    "name": "Marketing Telemetry Snapshot Exposure #9",
+    "description": "Surfaces exposed Marketing telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/telemetry-snapshot-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-marketing-10",
+    "name": "Marketing Telemetry Snapshot Exposure #10",
+    "description": "Surfaces exposed Marketing telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/telemetry-snapshot-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-marketing-06",
+    "name": "Marketing Debug Trace Log Leak #6",
+    "description": "Detects leaked Marketing debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/debug-trace-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-marketing-07",
+    "name": "Marketing Debug Trace Log Leak #7",
+    "description": "Detects leaked Marketing debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/marketing/debug-trace-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-marketing-08",
+    "name": "Marketing Debug Trace Log Leak #8",
+    "description": "Detects leaked Marketing debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/debug-trace-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-marketing-09",
+    "name": "Marketing Debug Trace Log Leak #9",
+    "description": "Detects leaked Marketing debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/debug-trace-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-marketing-10",
+    "name": "Marketing Debug Trace Log Leak #10",
+    "description": "Detects leaked Marketing debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/debug-trace-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-marketing-06",
+    "name": "Marketing Database Backup Exposure #6",
+    "description": "Finds exposed Marketing database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/db-backup-06.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-marketing-07",
+    "name": "Marketing Database Backup Exposure #7",
+    "description": "Finds exposed Marketing database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/db-backup-07.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-marketing-08",
+    "name": "Marketing Database Backup Exposure #8",
+    "description": "Finds exposed Marketing database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/db-backup-08.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-marketing-09",
+    "name": "Marketing Database Backup Exposure #9",
+    "description": "Finds exposed Marketing database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/db-backup-09.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-marketing-10",
+    "name": "Marketing Database Backup Exposure #10",
+    "description": "Finds exposed Marketing database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/marketing/db-backup-10.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-marketing-06",
+    "name": "Marketing Compliance Report Leak #6",
+    "description": "Detects leaked Marketing compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/compliance-report-06.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-marketing-07",
+    "name": "Marketing Compliance Report Leak #7",
+    "description": "Detects leaked Marketing compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/marketing/compliance-report-07.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-marketing-08",
+    "name": "Marketing Compliance Report Leak #8",
+    "description": "Detects leaked Marketing compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/compliance-report-08.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-marketing-09",
+    "name": "Marketing Compliance Report Leak #9",
+    "description": "Detects leaked Marketing compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/compliance-report-09.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-marketing-10",
+    "name": "Marketing Compliance Report Leak #10",
+    "description": "Detects leaked Marketing compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/marketing/compliance-report-10.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "marketing"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-operations-06",
+    "name": "Operations Token Cache Dump #6",
+    "description": "Detects exposed Operations token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/token-cache-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-operations-07",
+    "name": "Operations Token Cache Dump #7",
+    "description": "Detects exposed Operations token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/token-cache-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-operations-08",
+    "name": "Operations Token Cache Dump #8",
+    "description": "Detects exposed Operations token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/token-cache-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-operations-09",
+    "name": "Operations Token Cache Dump #9",
+    "description": "Detects exposed Operations token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/token-cache-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-operations-10",
+    "name": "Operations Token Cache Dump #10",
+    "description": "Detects exposed Operations token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/token-cache-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-operations-06",
+    "name": "Operations Session Ledger Leak #6",
+    "description": "Catches leaked Operations session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/sessions-ledger-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-operations-07",
+    "name": "Operations Session Ledger Leak #7",
+    "description": "Catches leaked Operations session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/sessions-ledger-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-operations-08",
+    "name": "Operations Session Ledger Leak #8",
+    "description": "Catches leaked Operations session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/sessions-ledger-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-operations-09",
+    "name": "Operations Session Ledger Leak #9",
+    "description": "Catches leaked Operations session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/sessions-ledger-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-operations-10",
+    "name": "Operations Session Ledger Leak #10",
+    "description": "Catches leaked Operations session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/sessions-ledger-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-operations-06",
+    "name": "Operations Config Export Exposure #6",
+    "description": "Finds world-readable Operations configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/config-export-06.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-operations-07",
+    "name": "Operations Config Export Exposure #7",
+    "description": "Finds world-readable Operations configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/config-export-07.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-operations-08",
+    "name": "Operations Config Export Exposure #8",
+    "description": "Finds world-readable Operations configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/config-export-08.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-operations-09",
+    "name": "Operations Config Export Exposure #9",
+    "description": "Finds world-readable Operations configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/config-export-09.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-operations-10",
+    "name": "Operations Config Export Exposure #10",
+    "description": "Finds world-readable Operations configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/config-export-10.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-operations-06",
+    "name": "Operations User Dump Exposure #6",
+    "description": "Detects exposed Operations user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/user-dump-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-operations-07",
+    "name": "Operations User Dump Exposure #7",
+    "description": "Detects exposed Operations user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/operations/user-dump-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-operations-08",
+    "name": "Operations User Dump Exposure #8",
+    "description": "Detects exposed Operations user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/user-dump-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-operations-09",
+    "name": "Operations User Dump Exposure #9",
+    "description": "Detects exposed Operations user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/user-dump-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-operations-10",
+    "name": "Operations User Dump Exposure #10",
+    "description": "Detects exposed Operations user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/user-dump-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-operations-06",
+    "name": "Operations Billing Export Exposure #6",
+    "description": "Identifies Operations billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/billing-export-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-operations-07",
+    "name": "Operations Billing Export Exposure #7",
+    "description": "Identifies Operations billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/operations/billing-export-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-operations-08",
+    "name": "Operations Billing Export Exposure #8",
+    "description": "Identifies Operations billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/billing-export-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-operations-09",
+    "name": "Operations Billing Export Exposure #9",
+    "description": "Identifies Operations billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/billing-export-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-operations-10",
+    "name": "Operations Billing Export Exposure #10",
+    "description": "Identifies Operations billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/billing-export-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-operations-06",
+    "name": "Operations Webhook Registry Leak #6",
+    "description": "Detects leaked Operations webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/webhooks-registry-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-operations-07",
+    "name": "Operations Webhook Registry Leak #7",
+    "description": "Detects leaked Operations webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/webhooks-registry-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-operations-08",
+    "name": "Operations Webhook Registry Leak #8",
+    "description": "Detects leaked Operations webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/webhooks-registry-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-operations-09",
+    "name": "Operations Webhook Registry Leak #9",
+    "description": "Detects leaked Operations webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/webhooks-registry-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-operations-10",
+    "name": "Operations Webhook Registry Leak #10",
+    "description": "Detects leaked Operations webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/webhooks-registry-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-operations-06",
+    "name": "Operations Telemetry Snapshot Exposure #6",
+    "description": "Surfaces exposed Operations telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/telemetry-snapshot-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-operations-07",
+    "name": "Operations Telemetry Snapshot Exposure #7",
+    "description": "Surfaces exposed Operations telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/operations/telemetry-snapshot-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-operations-08",
+    "name": "Operations Telemetry Snapshot Exposure #8",
+    "description": "Surfaces exposed Operations telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/telemetry-snapshot-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-operations-09",
+    "name": "Operations Telemetry Snapshot Exposure #9",
+    "description": "Surfaces exposed Operations telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/telemetry-snapshot-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-operations-10",
+    "name": "Operations Telemetry Snapshot Exposure #10",
+    "description": "Surfaces exposed Operations telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/telemetry-snapshot-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-operations-06",
+    "name": "Operations Debug Trace Log Leak #6",
+    "description": "Detects leaked Operations debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/debug-trace-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-operations-07",
+    "name": "Operations Debug Trace Log Leak #7",
+    "description": "Detects leaked Operations debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/operations/debug-trace-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-operations-08",
+    "name": "Operations Debug Trace Log Leak #8",
+    "description": "Detects leaked Operations debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/debug-trace-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-operations-09",
+    "name": "Operations Debug Trace Log Leak #9",
+    "description": "Detects leaked Operations debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/debug-trace-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-operations-10",
+    "name": "Operations Debug Trace Log Leak #10",
+    "description": "Detects leaked Operations debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/debug-trace-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-operations-06",
+    "name": "Operations Database Backup Exposure #6",
+    "description": "Finds exposed Operations database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/db-backup-06.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-operations-07",
+    "name": "Operations Database Backup Exposure #7",
+    "description": "Finds exposed Operations database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/db-backup-07.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-operations-08",
+    "name": "Operations Database Backup Exposure #8",
+    "description": "Finds exposed Operations database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/db-backup-08.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-operations-09",
+    "name": "Operations Database Backup Exposure #9",
+    "description": "Finds exposed Operations database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/db-backup-09.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-operations-10",
+    "name": "Operations Database Backup Exposure #10",
+    "description": "Finds exposed Operations database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/operations/db-backup-10.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-operations-06",
+    "name": "Operations Compliance Report Leak #6",
+    "description": "Detects leaked Operations compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/compliance-report-06.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-operations-07",
+    "name": "Operations Compliance Report Leak #7",
+    "description": "Detects leaked Operations compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/operations/compliance-report-07.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-operations-08",
+    "name": "Operations Compliance Report Leak #8",
+    "description": "Detects leaked Operations compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/compliance-report-08.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-operations-09",
+    "name": "Operations Compliance Report Leak #9",
+    "description": "Detects leaked Operations compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/compliance-report-09.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-operations-10",
+    "name": "Operations Compliance Report Leak #10",
+    "description": "Detects leaked Operations compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/operations/compliance-report-10.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "operations"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-product-06",
+    "name": "Product Token Cache Dump #6",
+    "description": "Detects exposed Product token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/token-cache-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-product-07",
+    "name": "Product Token Cache Dump #7",
+    "description": "Detects exposed Product token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/token-cache-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-product-08",
+    "name": "Product Token Cache Dump #8",
+    "description": "Detects exposed Product token cache exports leaking bearer secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/token-cache-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-product-09",
+    "name": "Product Token Cache Dump #9",
+    "description": "Detects exposed Product token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/token-cache-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-token-cache-product-10",
+    "name": "Product Token Cache Dump #10",
+    "description": "Detects exposed Product token cache exports leaking bearer secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/token-cache-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)token",
+        "(?i)secret",
+        "(?i)bearer"
+      ]
+    },
+    "tags": [
+      "api",
+      "credentials",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-product-06",
+    "name": "Product Session Ledger Leak #6",
+    "description": "Catches leaked Product session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/sessions-ledger-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-product-07",
+    "name": "Product Session Ledger Leak #7",
+    "description": "Catches leaked Product session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/sessions-ledger-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-product-08",
+    "name": "Product Session Ledger Leak #8",
+    "description": "Catches leaked Product session ledgers disclosing JWTs and expirations.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/sessions-ledger-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-product-09",
+    "name": "Product Session Ledger Leak #9",
+    "description": "Catches leaked Product session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/sessions-ledger-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-session-ledger-product-10",
+    "name": "Product Session Ledger Leak #10",
+    "description": "Catches leaked Product session ledgers disclosing JWTs and expirations.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/sessions-ledger-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)session",
+        "(?i)jwt",
+        "(?i)exp"
+      ]
+    },
+    "tags": [
+      "api",
+      "sessions",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-product-06",
+    "name": "Product Config Export Exposure #6",
+    "description": "Finds world-readable Product configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/config-export-06.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-product-07",
+    "name": "Product Config Export Exposure #7",
+    "description": "Finds world-readable Product configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/config-export-07.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-product-08",
+    "name": "Product Config Export Exposure #8",
+    "description": "Finds world-readable Product configuration exports exposing environment secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/config-export-08.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-product-09",
+    "name": "Product Config Export Exposure #9",
+    "description": "Finds world-readable Product configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/config-export-09.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-config-export-product-10",
+    "name": "Product Config Export Exposure #10",
+    "description": "Finds world-readable Product configuration exports exposing environment secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/config-export-10.yaml",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)config",
+        "(?i)environment",
+        "(?i)secret"
+      ]
+    },
+    "tags": [
+      "api",
+      "config",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-product-06",
+    "name": "Product User Dump Exposure #6",
+    "description": "Detects exposed Product user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/user-dump-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-product-07",
+    "name": "Product User Dump Exposure #7",
+    "description": "Detects exposed Product user exports leaking directory records.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/product/user-dump-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-product-08",
+    "name": "Product User Dump Exposure #8",
+    "description": "Detects exposed Product user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/user-dump-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-product-09",
+    "name": "Product User Dump Exposure #9",
+    "description": "Detects exposed Product user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/user-dump-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-user-dump-product-10",
+    "name": "Product User Dump Exposure #10",
+    "description": "Detects exposed Product user exports leaking directory records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/user-dump-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)email",
+        "(?i)user",
+        "(?i)id"
+      ]
+    },
+    "tags": [
+      "api",
+      "intel",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-product-06",
+    "name": "Product Billing Export Exposure #6",
+    "description": "Identifies Product billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/billing-export-06.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-product-07",
+    "name": "Product Billing Export Exposure #7",
+    "description": "Identifies Product billing exports containing transaction data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/product/billing-export-07.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-product-08",
+    "name": "Product Billing Export Exposure #8",
+    "description": "Identifies Product billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/billing-export-08.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-product-09",
+    "name": "Product Billing Export Exposure #9",
+    "description": "Identifies Product billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/billing-export-09.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-billing-export-product-10",
+    "name": "Product Billing Export Exposure #10",
+    "description": "Identifies Product billing exports containing transaction data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/billing-export-10.csv",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)invoice",
+        "(?i)amount",
+        "(?i)currency"
+      ]
+    },
+    "tags": [
+      "api",
+      "billing",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-product-06",
+    "name": "Product Webhook Registry Leak #6",
+    "description": "Detects leaked Product webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/webhooks-registry-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-product-07",
+    "name": "Product Webhook Registry Leak #7",
+    "description": "Detects leaked Product webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/webhooks-registry-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-product-08",
+    "name": "Product Webhook Registry Leak #8",
+    "description": "Detects leaked Product webhook registries exposing callback secrets.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/webhooks-registry-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-product-09",
+    "name": "Product Webhook Registry Leak #9",
+    "description": "Detects leaked Product webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/webhooks-registry-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-webhook-registry-product-10",
+    "name": "Product Webhook Registry Leak #10",
+    "description": "Detects leaked Product webhook registries exposing callback secrets.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/webhooks-registry-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)webhook",
+        "(?i)callback",
+        "(?i)signature"
+      ]
+    },
+    "tags": [
+      "api",
+      "integrations",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-product-06",
+    "name": "Product Telemetry Snapshot Exposure #6",
+    "description": "Surfaces exposed Product telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/telemetry-snapshot-06.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-product-07",
+    "name": "Product Telemetry Snapshot Exposure #7",
+    "description": "Surfaces exposed Product telemetry snapshots leaking internal metrics.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/product/telemetry-snapshot-07.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-product-08",
+    "name": "Product Telemetry Snapshot Exposure #8",
+    "description": "Surfaces exposed Product telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/telemetry-snapshot-08.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-product-09",
+    "name": "Product Telemetry Snapshot Exposure #9",
+    "description": "Surfaces exposed Product telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/telemetry-snapshot-09.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-telemetry-snapshot-product-10",
+    "name": "Product Telemetry Snapshot Exposure #10",
+    "description": "Surfaces exposed Product telemetry snapshots leaking internal metrics.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/telemetry-snapshot-10.json",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)telemetry",
+        "(?i)metric",
+        "(?i)timestamp"
+      ]
+    },
+    "tags": [
+      "api",
+      "telemetry",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-product-06",
+    "name": "Product Debug Trace Log Leak #6",
+    "description": "Detects leaked Product debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/debug-trace-06.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-product-07",
+    "name": "Product Debug Trace Log Leak #7",
+    "description": "Detects leaked Product debug traces revealing stack data.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/product/debug-trace-07.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-product-08",
+    "name": "Product Debug Trace Log Leak #8",
+    "description": "Detects leaked Product debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/debug-trace-08.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-product-09",
+    "name": "Product Debug Trace Log Leak #9",
+    "description": "Detects leaked Product debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/debug-trace-09.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-debug-trace-product-10",
+    "name": "Product Debug Trace Log Leak #10",
+    "description": "Detects leaked Product debug traces revealing stack data.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/debug-trace-10.log",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)trace",
+        "(?i)exception",
+        "(?i)stack"
+      ]
+    },
+    "tags": [
+      "api",
+      "debug",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-product-06",
+    "name": "Product Database Backup Exposure #6",
+    "description": "Finds exposed Product database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/db-backup-06.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-product-07",
+    "name": "Product Database Backup Exposure #7",
+    "description": "Finds exposed Product database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/db-backup-07.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-product-08",
+    "name": "Product Database Backup Exposure #8",
+    "description": "Finds exposed Product database backups with raw records.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/db-backup-08.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-product-09",
+    "name": "Product Database Backup Exposure #9",
+    "description": "Finds exposed Product database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/db-backup-09.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-database-backup-product-10",
+    "name": "Product Database Backup Exposure #10",
+    "description": "Finds exposed Product database backups with raw records.",
+    "severity": "high",
+    "method": "GET",
+    "path": "/api/product/db-backup-10.sql",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)insert",
+        "(?i)password",
+        "(?i)api_key"
+      ]
+    },
+    "tags": [
+      "api",
+      "database",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-product-06",
+    "name": "Product Compliance Report Leak #6",
+    "description": "Detects leaked Product compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/compliance-report-06.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-product-07",
+    "name": "Product Compliance Report Leak #7",
+    "description": "Detects leaked Product compliance reports disclosing control evidence.",
+    "severity": "low",
+    "method": "GET",
+    "path": "/api/product/compliance-report-07.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-product-08",
+    "name": "Product Compliance Report Leak #8",
+    "description": "Detects leaked Product compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/compliance-report-08.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-product-09",
+    "name": "Product Compliance Report Leak #9",
+    "description": "Detects leaked Product compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/compliance-report-09.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "product"
+    ]
+  },
+  {
+    "id": "api-regex-compliance-report-product-10",
+    "name": "Product Compliance Report Leak #10",
+    "description": "Detects leaked Product compliance reports disclosing control evidence.",
+    "severity": "medium",
+    "method": "GET",
+    "path": "/api/product/compliance-report-10.pdf",
+    "matchers": {
+      "status": [
+        200
+      ],
+      "regex": [
+        "(?i)compliance",
+        "(?i)control",
+        "(?i)finding"
+      ]
+    },
+    "tags": [
+      "api",
+      "compliance",
+      "product"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- update the automation generator to produce 10 variants per exposure and refresh regex set files automatically
- append the newly generated 1000 API regex templates covering indices 06-10 for every category/exposure combination
- synchronize the per-slug regex set collections with the expanded template catalog

## Testing
- python automations/build_api_regex_rules.py

------
https://chatgpt.com/codex/tasks/task_b_68cf9cc78c148329962dab1b2926914a