### PR TITLE
Fix Base64 secret regex template

### DIFF
--- a/main.py
+++ b/main.py
@@ -339,7 +339,7 @@ SECRET_PATTERN_BLUEPRINTS: list[tuple[str, str]] = [
     ("Header Bearer", r"(?i){keyword}\s+Bearer\s+[A-Za-z0-9\-._~+/]+=*"),
     ("JWT Blob", r"(?i){keyword}\s*[:=]\s*['\"]?ey[A-Za-z0-9_-]{{10,}}\.[A-Za-z0-9_-]{{10,}}\.[A-Za-z0-9_-]{{10,}}"),
     ("UUID Token", r"(?i){keyword}\s*[:=]\s*['\"]?[0-9a-f]{{8}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{12}}"),
-    ("Base64 Secret", r"(?i){keyword}\s*[:=]\s*['\"]?[A-Za-z0-9/+]{32,}={0,2}"),
+    ("Base64 Secret", r"(?i){keyword}\s*[:=]\s*['\"]?[A-Za-z0-9/+]{{32,}}={{0,2}}"),
     ("Comment Hint", r"(?i)//\s*{keyword}\s*[:=]\s*[A-Za-z0-9\-_/]{{12,}}"),
     ("HTML Data Attribute", r"(?i)data-{keyword}=['\"]?[A-Za-z0-9\-_/]{{16,}}"),
     ("Env Export", r"(?i)export\s+{keyword}\s*=\s*['\"]?[A-Za-z0-9\-_/]{{16,}}"),


### PR DESCRIPTION
## Summary
- escape quantifier braces in the Base64 secret regex template to avoid format-time KeyErrors

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_b_68d11ecce6908329afd11ec3d440426c