### PR TITLE
Fix secret pattern formatting

### DIFF
--- a/main.py
+++ b/main.py
@@ -364,7 +364,9 @@ def _generate_secret_pattern_catalog(additional_count: int = 1000) -> list[tuple
         for suffix, template in SECRET_PATTERN_BLUEPRINTS:
             if len(extras) >= additional_count:
                 break
-            compiled = re.compile(template.format(keyword=keyword_regex))
+            rendered = template.replace("{keyword}", keyword_regex)
+            rendered = rendered.replace("{{", "{").replace("}}", "}")
+            compiled = re.compile(rendered)
             extras.append((f"{keyword_title} {suffix}", compiled))
         if len(extras) >= additional_count:
             break


### PR DESCRIPTION
## Summary
- avoid using Python str.format for secret pattern templates to prevent brace parsing errors
- render templates by replacing the keyword token and normalising escaped braces before compilation

## Testing
- `python3 main.py --help` *(fails: missing requests dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d127ffc868832991b36aac7a5154ad